### PR TITLE
Support of generic aiida plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,19 @@ To manage the repo we use [hatch]{.title-ref} please install it
 
 ``` bash
 pip install hatch
+hatch shell # activate shell as dev environment 
 hatch test # run tests
 hatch fmt # run formatting
 hatch run docs:build # build docs
 hatch run docs:serve # live preview of doc for development
+```
+
+### Tests
+``` bash
+pip install hatch
+verdi devel launch-add # creates required codes
+verdi presto
+hatch test
 ```
 
 ## Resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,14 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Atmospheric Science',
 ]
 keywords = ["wc", "workflow"," icon", "aiida", "aiida-workgraph"]
-requires-python = '>=3.12'
+requires-python = '~=3.12'
 dependencies = [
   "isoduration",
   "pydantic",
   "pydantic-yaml",
-  "aiida-core>=2.5"
+  "aiida-core>=2.5",
+  'aiida-workgraph[widget]==0.3.14',
+  'node_graph==0.0.11',
 ]
 
 [tool.pytest.ini_options]
@@ -55,7 +57,11 @@ ignore = [
 [tool.hatch.version]
 path = "src/wcflow/__init__.py"
 
+[project.optional-dependencies]
+tests = ["pytest"]
+
 [tool.hatch.envs.hatch-test]
+extras = ["tests"]
 extra-dependencies = [
     "ipdb"
 ]

--- a/src/wcflow/_utils.py
+++ b/src/wcflow/_utils.py
@@ -1,0 +1,17 @@
+import aiida.orm
+
+
+class OrmUtils:
+    @staticmethod
+    def convert_to_class(type_: str) -> aiida.orm.utils.node.AbstractNodeMeta:
+        if type_ == "file":
+            return aiida.orm.SinglefileData
+        elif type_ == "dir":
+            return aiida.orm.FolderData
+        elif type_ == "int":
+            return aiida.orm.Int
+        elif type_ == "float":
+            return aiida.orm.Float
+        else:
+            raise ValueError(f"Type {type_} is unknown.")
+

--- a/src/wcflow/_utils.py
+++ b/src/wcflow/_utils.py
@@ -12,6 +12,8 @@ class OrmUtils:
             return aiida.orm.Int
         elif type_ == "float":
             return aiida.orm.Float
+        elif type_ == "remote":
+            return aiida.orm.RemoteData
         else:
             raise ValueError(f"Type {type_} is unknown.")
 

--- a/src/wcflow/core.py
+++ b/src/wcflow/core.py
@@ -72,10 +72,6 @@ class _DataBase:
         return self._src
 
     @property
-    def path(self) -> Path:
-        return self._path
-
-    @property
     def lag(self) -> list[Duration]:
         return self._lag
 
@@ -657,9 +653,10 @@ class UnrolledCycle(_CycleBase):
 
 
 class Workflow:
-    def __init__(self, name: str, cycles: list[Cycle]):
+    def __init__(self, name: str, cycles: list[Cycle], computer: str):
         self._name = name
         self._cycles = cycles
+        self._computer = computer
         for cycle in self._cycles:
             cycle.workflow = self
         self._validate_cycles()
@@ -691,6 +688,10 @@ class Workflow:
     @property
     def cycles(self) -> list[Cycle]:
         return self._cycles
+
+    @property
+    def computer(self) -> str:
+        return self._computer
 
     def is_available_on_init(self, data: UnrolledData) -> bool:
         """Determines if the data is available on init of the workflow."""

--- a/src/wcflow/core.py
+++ b/src/wcflow/core.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from isoduration import parse_duration
 from isoduration.types import Duration
 
-from wcflow._utils import TimeUtils
+from wcflow.parsing._utils import TimeUtils
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/src/wcflow/parsing/_yaml_data_models.py
+++ b/src/wcflow/parsing/_yaml_data_models.py
@@ -112,6 +112,7 @@ class ConfigData(_NamedBaseModel):
     type: str | None = None
     src: str | int | dict | None = None
     format: str | None = None
+    computer: str | None = None
 
     @field_validator("type")
     @classmethod
@@ -265,6 +266,7 @@ class ConfigWorkflow(BaseModel):
     data: list[ConfigData]
     data_dict: dict = {}
     task_dict: dict = {}
+    computer: str | None = None
 
     @field_validator("start_date", "end_date", mode="before")
     @classmethod
@@ -283,7 +285,7 @@ class ConfigWorkflow(BaseModel):
         self.task_dict = {task.name: task for task in self.tasks}
 
         core_cycles = [self._to_core_cycle(cycle) for cycle in self.cycles]
-        return core.Workflow(self.name, core_cycles)
+        return core.Workflow(self.name, core_cycles, computer=self.computer)
 
     def _to_core_cycle(self, cycle: ConfigCycle) -> core.Cycle:
         core_tasks = [self._to_core_task(task) for task in cycle.tasks]

--- a/src/wcflow/parsing/_yaml_data_models.py
+++ b/src/wcflow/parsing/_yaml_data_models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from datetime import datetime
 from os.path import expandvars
 from pathlib import Path
@@ -87,7 +86,7 @@ class ConfigTask(_NamedBaseModel):
     command: str | None = None
     # these are global commands_options, I think we can remove arg_options to simplify
     command_options: str | None = None
-    # general 
+    # general
     plugin: str | None = None
     computer: str | None = None
     code: str | None = None
@@ -131,7 +130,7 @@ class ConfigData(_NamedBaseModel):
         if isinstance(value, str):
             return expandvars(value)
         elif isinstance(value, dict):
-            raise NotImplementedError()
+            raise NotImplementedError
         else:
             return value
 

--- a/src/wcflow/workgraph.py
+++ b/src/wcflow/workgraph.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING, Any
 import aiida.common
 import aiida.orm
 import aiida_workgraph.engine.utils  # type: ignore[import-untyped]
-from aiida_workgraph import WorkGraph  # type: ignore[import-untyped]
 from aiida.plugins.factories import CalculationFactory
+from aiida_workgraph import WorkGraph  # type: ignore[import-untyped]
 
 from ._utils import OrmUtils
+
 if TYPE_CHECKING:
     from aiida_workgraph.socket import TaskSocket  # type: ignore[import-untyped]
 
@@ -147,7 +148,7 @@ class AiidaWorkGraph:
         if plugin_entry_point == "shell":
             orm_class = OrmUtils.convert_to_class(input_.type)
         else:
-            # TODO catch if entry_point does not exist 
+            # TODO catch if entry_point does not exist
             workflow_class = CalculationFactory(plugin_entry_point)
 
             if (port := workflow_class.spec().inputs.get(input_.port_name, None)) is None:

--- a/src/wcflow/workgraph.py
+++ b/src/wcflow/workgraph.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import aiida.common
+import aiida.orm
+import aiida_workgraph.engine.utils  # type: ignore[import-untyped]
+from aiida_workgraph import WorkGraph  # type: ignore[import-untyped]
+from aiida.plugins.factories import CalculationFactory
+
+from ._utils import OrmUtils
+if TYPE_CHECKING:
+    from aiida_workgraph.socket import TaskSocket  # type: ignore[import-untyped]
+
+    from wcflow import core
+
+
+# This is hack to aiida-workgraph, merging this into aiida-workgraph properly would require
+# some major refactor see issue https://github.com/aiidateam/aiida-workgraph/issues/168
+# It might be better to give up on the graph like construction and just create the task
+# directly with inputs, arguments and outputs
+def _prepare_for_shell_task(task: dict, kwargs: dict) -> dict:
+    """Prepare the inputs for ShellTask"""
+    from aiida.common import lang
+    from aiida.orm import AbstractCode
+    from aiida_shell.launch import convert_nodes_single_file_data, prepare_code
+
+    command = kwargs.pop("command", None)
+    resolve_command = kwargs.pop("resolve_command", False)
+    metadata = kwargs.pop("metadata", {})
+    # setup code
+    if isinstance(command, str):
+        computer = (metadata or {}).get("options", {}).pop("computer", None)
+        code = prepare_code(command, computer, resolve_command)
+    else:
+        lang.type_check(command, AbstractCode)
+        code = command
+    # update the tasks with links
+    nodes = convert_nodes_single_file_data(kwargs.pop("nodes", {}))
+    # find all keys in kwargs start with "nodes."
+    for key in list(kwargs.keys()):
+        if key.startswith("nodes."):
+            nodes[key[6:]] = kwargs.pop(key)
+    metadata.update({"call_link_label": task["name"]})
+
+    default_outputs = {"remote_folder", "remote_stash", "retrieved", "_outputs", "_wait", "stdout", "stderr"}
+    task_outputs = {task["outputs"][i]["name"] for i in range(len(task["outputs"]))}
+    task_outputs = task_outputs.union(set(kwargs.pop("outputs", [])))
+    missing_outputs = task_outputs.difference(default_outputs)
+    return {
+        "code": code,
+        "nodes": nodes,
+        "filenames": kwargs.pop("filenames", {}),
+        "arguments": kwargs.pop("arguments", []),
+        "outputs": list(missing_outputs),
+        "parser": kwargs.pop("parser", None),
+        "metadata": metadata or {},
+    }
+
+
+aiida_workgraph.engine.utils.prepare_for_shell_task = _prepare_for_shell_task
+
+
+class AiidaWorkGraph:
+    def __init__(self, core_workflow: core.Workflow):
+        # Needed for date indexing
+        self._core_workflow = core_workflow
+
+        self._validate_workflow()
+
+        self._workgraph = WorkGraph(core_workflow.name)
+
+        # stores the input data available on initialization
+        self._aiida_data_nodes: dict[str, aiida_workgraph.orm.Data] = {}
+        # stores the outputs sockets of tasks
+        self._aiida_socket_nodes: dict[str, TaskSocket] = {}
+        self._aiida_task_nodes: dict[str, aiida_workgraph.Task] = {}
+
+        self._add_aiida_initial_data_nodes()
+
+        self._add_aiida_task_nodes()
+        self._add_aiida_links()
+
+        self._add_aiida_plugin_task_nodes()
+        self._add_aiida_plugin_links()
+
+    def _validate_workflow(self):
+        """Checks if the defined workflow is correctly referencing key names."""
+        for cycle in self._core_workflow.unrolled_cycles:
+            try:
+                aiida.common.validate_link_label(cycle.name)
+            except ValueError as exception:
+                msg = f"Raised error when validating cycle name '{cycle.name}': {exception.args[0]}"
+                raise ValueError(msg) from exception
+            for task in cycle.unrolled_tasks:
+                try:
+                    aiida.common.validate_link_label(task.name)
+                except ValueError as exception:
+                    msg = f"Raised error when validating task name '{cycle.name}': {exception.args[0]}"
+                    raise ValueError(msg) from exception
+                for input_ in task.unrolled_inputs:
+                    try:
+                        aiida.common.validate_link_label(task.name)
+                    except ValueError as exception:
+                        msg = f"Raised error when validating input name '{input_.name}': {exception.args[0]}"
+                        raise ValueError(msg) from exception
+                for output in task.unrolled_outputs:
+                    try:
+                        aiida.common.validate_link_label(task.name)
+                    except ValueError as exception:
+                        msg = f"Raised error when validating output name '{output.name}': {exception.args[0]}"
+                        raise ValueError(msg) from exception
+        # - Warning if output nodes that are overwritten by other tasks before usage, if this actually happens?
+
+    def _add_aiida_initial_data_nodes(self):
+        """
+        Nodes that correspond to data that are available on initialization of the workflow
+        """
+        for cycle in self._core_workflow.unrolled_cycles:
+            for task in cycle.unrolled_tasks:
+                for input_ in task.unrolled_inputs:
+                    if self._core_workflow.is_available_on_init(input_):
+                        self._add_aiida_input_data_node(input_, task.plugin)
+
+    @staticmethod
+    def parse_to_aiida_label(label: str) -> str:
+        return label.replace("-", "_").replace(" ", "_").replace(":", "_")
+
+    @staticmethod
+    def get_aiida_label_from_unrolled_data(data: core.UnrolledData) -> str:
+        """ """
+        return AiidaWorkGraph.parse_to_aiida_label(f"{data.name}_{data.unrolled_date}")
+
+    @staticmethod
+    def get_aiida_label_from_unrolled_task(task: core.UnrolledTask) -> str:
+        """ """
+        return AiidaWorkGraph.parse_to_aiida_label(
+            f"{task.unrolled_cycle.name}_" f"{task.unrolled_cycle.unrolled_date}_" f"{task.name}"
+        )
+
+    def _add_aiida_input_data_node(self, input_: core.UnrolledData, plugin_entry_point: str):
+        """
+        Create an :class:`aiida.orm.Data` instance from this wc data instance.
+
+        :param input: ...
+        """
+        if plugin_entry_point == "shell":
+            orm_class = OrmUtils.convert_to_class(input_.type)
+        else:
+            # TODO catch if entry_point does not exist 
+            workflow_class = CalculationFactory(plugin_entry_point)
+
+            if (port := workflow_class.spec().inputs.get(input_.port_name, None)) is None:
+                raise ValueError(f"Port name {input_.port_name} for input {input_} does not exist. Here a list of supported port name {workflow_class.spec().inputs.keys()}")
+
+            orm_class = OrmUtils.convert_to_class(input_.type)
+            if orm_class not in port.valid_type:
+                raise ValueError(f"For input {input_} the type {input_.type} was translated to {orm_class} and is not a supported type for port {input_.port_name}. Supported types are {port.valid_type}.")
+
+        label = AiidaWorkGraph.get_aiida_label_from_unrolled_data(input_)
+        if orm_class is aiida.orm.FolderData:
+            orm_instance = aiida.orm.FolderData(tree=input_.src, label=label)
+        else:
+            orm_instance = orm_class(input_.src, label=label)
+
+        self._aiida_data_nodes[label] = orm_instance
+
+    def _add_aiida_task_nodes(self):
+        for cycle in self._core_workflow.unrolled_cycles:
+            for task in cycle.unrolled_tasks:
+                if task.plugin == "shell":
+                    self._add_aiida_task_node(task)
+        # after creation we can link the wait_on tasks
+        for cycle in self._core_workflow.unrolled_cycles:
+            for task in cycle.unrolled_tasks:
+                if task.plugin == "shell":
+                    self._link_wait_on_to_task(task)
+
+    def _add_aiida_task_node(self, task: core.UnrolledTask):
+        label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(task)
+        workgraph_task = self._workgraph.tasks.new(
+            "ShellJob",
+            name=label,
+            command=task.command,
+            # TODO pickling error
+            #metadata={"computer": aiida.orm.load_computer(task.computer)},
+            #computer=task.computer,
+            #metadata={"computer": task.computer},
+            #code=task.code,
+            code=aiida.orm.load_code(task.code),
+        )
+        workgraph_task.set({"arguments": []})
+        workgraph_task.set({"nodes": {}})
+        self._aiida_task_nodes[label] = workgraph_task
+
+    def _link_wait_on_to_task(self, task: core.UnrolledTask):
+        label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(task)
+        workgraph_task = self._aiida_task_nodes[label]
+        wait_on_tasks = []
+        for depend in task.unrolled_depends:
+            wait_on_task_label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(depend.depend_on_task)
+            wait_on_tasks.append(self._aiida_task_nodes[wait_on_task_label])
+        workgraph_task.wait = wait_on_tasks
+
+    def _add_aiida_plugin_task_nodes(self):
+        for cycle in self._core_workflow.unrolled_cycles:
+            for task in cycle.unrolled_tasks:
+                if task.plugin != "shell":
+                    self._add_aiida_plugin_task_node(task)
+        # after creation we can link the wait_on tasks
+        for cycle in self._core_workflow.unrolled_cycles:
+            for task in cycle.unrolled_tasks:
+                if task.plugin != "shell":
+                    self._link_wait_on_to_task(task)
+
+    def _add_aiida_plugin_task_node(self, task: core.UnrolledTask):
+        label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(task)
+        workflow_class = CalculationFactory(task.plugin)
+
+        workgraph_task = self._workgraph.tasks.new(
+            workflow_class,
+            name=label,
+            #metadata={"computer": aiida.orm.load_computer(task.computer)},
+            code=aiida.orm.load_code(task.code),
+            #computer=task.computer,
+            #metadata={"computer": task.computer},
+            #code=task.code,
+        )
+        self._aiida_task_nodes[label] = workgraph_task
+
+    def _add_aiida_links(self):
+        for cycle in self._core_workflow.unrolled_cycles:
+            self._add_aiida_links_from_cycle(cycle)
+
+    def _add_aiida_links_from_cycle(self, cycle: core.UnrolledCycle):
+        for task in cycle.unrolled_tasks:
+            if task == "shell":
+                for input_ in task.unrolled_inputs:
+                    self._link_input_to_task(input_)
+                for output in task.unrolled_outputs:
+                    self._link_output_to_task(output)
+
+    def _link_input_to_task(self, input_: core.UnrolledData):
+        task_label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(input_.unrolled_task)
+        input_label = AiidaWorkGraph.get_aiida_label_from_unrolled_data(input_)
+        workgraph_task = self._aiida_task_nodes[task_label]
+        workgraph_task.inputs.new("Any", f"nodes.{input_label}")
+        workgraph_task.kwargs.append(f"nodes.{input_label}")
+
+        # resolve data
+        if (data_node := self._aiida_data_nodes.get(input_label)) is not None:
+            if (nodes := workgraph_task.inputs.get("nodes")) is None:
+                msg = f"Workgraph task {workgraph_task.name!r} did not initialize input nodes in the workgraph before linking. This is a bug in the code, please contact the developers by making an issue."
+                raise ValueError(msg)
+            nodes.value.update({f"{input_label}": data_node})
+        elif (output_socket := self._aiida_socket_nodes.get(input_label)) is not None:
+            self._workgraph.links.new(output_socket, workgraph_task.inputs[f"nodes.{input_label}"])
+        else:
+            msg = f"Input data node {input_label!r} was neither found in socket nodes nor in data nodes. The task {task_label!r} must have dependencies on inputs before they are created."
+            raise ValueError(msg)
+
+        # resolve arg_option
+        if (workgraph_task_arguments := workgraph_task.inputs.get("arguments")) is None:
+            msg = f"Workgraph task {workgraph_task.name!r} did not initialize arguments nodes in the workgraph before linking. This is a bug in the code, please contact devevlopers."
+            raise ValueError(msg)
+        if input_.arg_option is not None:
+            workgraph_task_arguments.value.append(f"{input_.arg_option}")
+        workgraph_task_arguments.value.append(f"{{{input_label}}}")
+
+    def _link_output_to_task(self, output: core.UnrolledData):
+        workgraph_task = self._aiida_task_nodes[AiidaWorkGraph.get_aiida_label_from_unrolled_task(output.unrolled_task)]
+        output_label = AiidaWorkGraph.get_aiida_label_from_unrolled_data(output)
+        output_socket = workgraph_task.outputs.new("Any", output.src)
+        self._aiida_socket_nodes[output_label] = output_socket
+
+    def _add_aiida_plugin_links(self):
+        for cycle in self._core_workflow.unrolled_cycles:
+            self._add_aiida_plugin_links_from_cycle(cycle)
+
+    def _add_aiida_plugin_links_from_cycle(self, cycle: core.UnrolledCycle):
+        for task in cycle.unrolled_tasks:
+            if task != "shell":
+                for input_ in task.unrolled_inputs:
+                    self._plugin_link_input_to_task(input_)
+                for output in task.unrolled_outputs:
+                    self._plugin_link_output_to_task(output)
+
+    def _plugin_link_input_to_task(self, input_: core.UnrolledData):
+        task_label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(input_.unrolled_task)
+        input_label = AiidaWorkGraph.get_aiida_label_from_unrolled_data(input_)
+        workgraph_task = self._aiida_task_nodes[task_label]
+
+        if (data_node := self._aiida_data_nodes.get(input_label)) is not None:
+            workgraph_task.set({input_.port_name: data_node})
+        elif (output_socket := self._aiida_socket_nodes.get(input_label)) is not None:
+            workgraph_task.set({input_.port_name: output_socket})
+        else:
+            msg = f"Input data node {input_label!r} was neither found in socket nodes nor in data nodes. The task {task_label!r} must have dependencies on inputs before they are created."
+            raise ValueError(msg)
+
+    def _plugin_link_output_to_task(self, output: core.UnrolledData):
+        task_label = AiidaWorkGraph.get_aiida_label_from_unrolled_task(output.unrolled_task)
+        workgraph_task = self._aiida_task_nodes[task_label]
+        output_socket = workgraph_task.outputs[output.port_name]
+        output_label = AiidaWorkGraph.get_aiida_label_from_unrolled_data(output)
+        self._aiida_socket_nodes[output_label] = output_socket
+
+    def run(
+        self,
+        inputs: None | dict[str, Any] = None,
+        metadata: None | dict[str, Any] = None,
+    ) -> dict[str, Any]:
+        return self._workgraph.run(inputs=inputs, metadata=metadata)
+
+    def submit(
+        self,
+        *,
+        inputs: None | dict[str, Any] = None,
+        wait: bool = False,
+        timeout: int = 60,
+        metadata: None | dict[str, Any] = None,
+    ) -> dict[str, Any]:
+        return self._workgraph.submit(inputs=inputs, wait=wait, timeout=timeout, metadata=metadata)

--- a/tests/files/configs/test_config_small.yml
+++ b/tests/files/configs/test_config_small.yml
@@ -11,7 +11,7 @@ cycles:
                 - b:
                     port_name: y
             outputs:
-                - sum1: 
+                - sum1:
                     port_name: sum
         - adder2:
             inputs:
@@ -25,25 +25,13 @@ cycles:
 tasks:
   - adder1:
       plugin: core.arithmetic.add
-      code: bash 
+      code: bash
       computer: localhost
   - adder2:
       plugin: core.arithmetic.add
-      code: bash 
+      code: bash
       computer: localhost
 data:
-  - icon_input:
-      type: file
-      src: $PWD/tests/files/data/input
-  - icon_input:
-      type: file
-      src: $PWD/tests/files/data/input
-  - icon_output:
-      type: file
-      src: output
-  - icon_restart:
-      type: file
-      src: restart
   - a:
       type: int
       src: 5
@@ -57,9 +45,3 @@ data:
       type: int
   - sum2:
       type: int
-  #- metadata:
-  #    type: dict
-  #    src:
-  #        options:
-  #            sleep: 1
-  #    port_name: metadata.options.sleep

--- a/tests/files/configs/test_config_small.yml
+++ b/tests/files/configs/test_config_small.yml
@@ -2,34 +2,39 @@
 start_date: 2026-01-01T00:00
 end_date: 2026-06-01T00:00
 cycles:
-  - bimonthly_tasks:
-      period: P2M
+  - single_cycle:
       tasks:
-        - icon:
+        - adder1:
             inputs:
-              - icon_restart:
-                  arg_option: --restart
-                  lag: -P2M
+                - a:
+                    port_name: x
+                - b:
+                    port_name: y
             outputs:
-              - icon_output
-              - icon_restart
-  - lastly:
-      tasks:
-        - cleanup:
-            depends:
-              - icon:
-                  date: 2026-05-01T00:00
+                - sum1: 
+                    port_name: sum
+        - adder2:
+            inputs:
+                - sum1:
+                    port_name: x
+                - c:
+                    port_name: y
+            outputs:
+                - sum2:
+                    port_name: sum
 tasks:
-  - icon:
-      plugin: shell
-      command: $PWD/tests/files/scripts/icon.py
-  - postproc:
-      plugin: shell
-      command: $PWD/tests/files/scripts/postproc.py
-  - cleanup:
-      plugin: shell
-      command: $PWD/tests/files/scripts/cleanup.py
+  - adder1:
+      plugin: core.arithmetic.add
+      code: bash 
+      computer: localhost
+  - adder2:
+      plugin: core.arithmetic.add
+      code: bash 
+      computer: localhost
 data:
+  - icon_input:
+      type: file
+      src: $PWD/tests/files/data/input
   - icon_input:
       type: file
       src: $PWD/tests/files/data/input
@@ -39,3 +44,22 @@ data:
   - icon_restart:
       type: file
       src: restart
+  - a:
+      type: int
+      src: 5
+  - b:
+      type: int
+      src: 2
+  - c:
+      type: int
+      src: 3
+  - sum1:
+      type: int
+  - sum2:
+      type: int
+  #- metadata:
+  #    type: dict
+  #    src:
+  #        options:
+  #            sleep: 1
+  #    port_name: metadata.options.sleep

--- a/tests/files/configs/test_config_small_icon_localhost.yml
+++ b/tests/files/configs/test_config_small_icon_localhost.yml
@@ -1,0 +1,70 @@
+---
+start_date: 2026-01-01T00:00
+end_date: 2026-06-01T00:00
+computer: localhost
+cycles:
+  - single_cycle:
+    #   period: P2M
+      tasks:
+        - icon_task:
+            inputs:
+              - icon_master_namelist:
+                  port_name: master_namelist
+              - icon_model_namelist:
+                  port_name: model_namelist
+              - grid_file:
+                  port_name: dynamics_grid_file
+              - ecrad_data:
+                  port_name: ecrad_data
+              - cloud_data:
+                  port_name: cloud_opt_props
+              - wet_whatever:
+                  port_name: dmin_wetgrowth_lookup
+              - rrtmg_sw:
+                  port_name: rrtmg_sw
+            outputs:
+              - latest_restart_file:
+                  port_name: latest_restart_file
+              - finish_status:
+                  port_name: finish_status
+tasks:
+  - icon_task:
+        plugin: aiida_icon.icon
+        code: icon
+        computer: localhost
+    #   icon_master_namelist:
+    #     src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/examples/exclaim_R02B04/icon_master.namelist
+    #     modify:
+    #       model_min_rank: 2
+
+data:
+  - icon_master_namelist:
+        src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/examples/exclaim_R02B04/icon_master.namelist
+        type: file
+        # modify:
+        #   model_min_rank: 2
+  - icon_model_namelist:
+        src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/tests/data/simple_icon_run/inputs/model.namelist
+        type: file
+  - grid_file:
+        src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/tests/data/simple_icon_run/inputs/icon_grid_simple.nc
+        type: remote
+  - ecrad_data:
+      src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/tests/data/simple_icon_run/inputs/ecrad_data.nc
+      type: remote
+  - cloud_data:
+      src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/tests/data/simple_icon_run/inputs/ECHAM6_CldOptProps.nc
+      type: remote
+  - wet_whatever:
+      src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/tests/data/simple_icon_run/inputs/dmin_wetgrowth_lookup.nc
+      type: remote
+  - rrtmg_sw:
+      src: /home/geiger_j/aiida_projects/aiida-icon-clm/git-repos/aiida-icon/tests/data/simple_icon_run/inputs/rrtmg_sw.nc
+      type: remote
+  - latest_restart_file:
+      type: file
+      src: .
+  - finish_status:
+      type: file
+      src: .
+

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -8,8 +8,18 @@ def config_file_small():
     return "files/configs/"
 
 
-@pytest.mark.parametrize(
-    "config_file", ["tests/files/configs/test_config_small.yml", "tests/files/configs/test_config_large.yml"]
-)  # , "tests/files/configs/test_config_large.yml"])
-def test_parse_config_file(config_file):
-    load_workflow_config(config_file)
+#@pytest.mark.parametrize(
+#    "config_file", ["tests/files/configs/test_config_small.yml", "tests/files/configs/test_config_large.yml"]
+#)
+#def test_convert_config_file(config_file):
+#    config_workflow = load_workflow_config(config_file)
+#    core_workflow = config_workflow.to_core_workflow()
+#    AiidaWorkGraph(core_workflow)
+
+
+@pytest.mark.parametrize("config_file", ["tests/files/configs/test_config_small.yml"])
+def test_run_config_file(config_file):
+    config_workflow = load_workflow_config(config_file)
+    core_workflow = config_workflow.to_core_workflow()
+    aiida_workflow = AiidaWorkGraph(core_workflow)
+    aiida_workflow.run()

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -1,7 +1,10 @@
+import aiida
 import pytest
 
 from wcflow.parsing import load_workflow_config
+from wcflow.workgraph import AiidaWorkGraph
 
+aiida.load_profile()
 
 @pytest.fixture
 def config_file_small():


### PR DESCRIPTION
### Idea

AiiDA plugins define their inputs and outputs in their `CalcJob`s and `Ẁorkchain`s with specific names. For example the [arithmetic add CalcJob](https://github.com/aiidateam/aiida-core/blob/98ffc331d154cc7717861fde6c908ec510003926/src/aiida/calculations/arithmetic/add.py#L27-L29)) has the inputs `x` and `y` as well as the output `sum`. We therefore need to specify these ports (how AiiDA calls them) in the yaml file to create the workgraph. In the aiida-shell plugin we did not need to do this because 
Each plugin defines a entry point which we can use to load the corresponding `CalcJob` or `WorkChain` using the factories
```python
from aiida.plugins.factories import CalculationFactory
ArithmeticAddCalculation = CalculationFactory("core.arithmetic.add")
# Retrieve input ports
print(ArithmeticAddCalculation.spec().inputs)
 ```
So with these two additional information (the entry point and the port names )in the YAML file we can run almost arbitrary calculations from aiida plugins (including aiida-icon). The reason why we did not need the port names for aiida-shell is because `ShellJob` creates dynamically its output ports from the outputs that are provided as inputs, so we took this to our advantage and use the name specified in the yaml file as output port names. For the input ports we also simplify the actual ports that would be `nodes` and `arguments`  ([see code](https://github.com/sphuber/aiida-shell/blob/14866d1450aa252ec414373e86e98611e2eae9db/src/aiida_shell/calculations/shell.py#L40)). The gist is that we treat aiida-shell differently, and we should continue to do so, because otherwise it becomes cumbersome to use.

### YAML syntax
Here you find (an example to run arithmetic add)[https://github.com/C2SM/ETHIOPIA/blob/plugins/tests/files/configs/test_config_small.yml]. A snippet of it to show how it is used to define a workflow.
```yaml
- adder1:
    inputs:
        - a:
            port_name: x
        - b:
            port_name: y
    outputs:
        - sum1: 
            port_name: sum
- adder2:
    inputs:
        - sum1:
            port_name: x
        - c:
            port_name: y
    outputs:
        - sum2:
            port_name: sum
```
Since the same data object can be used for different ports we need this information in the cycles.

### Definition of computer and code
We follow more the aiida logic to define computer and code information by just specifying the label given on definition.
```yaml
tasks:
  - adder1:
      plugin: core.arithmetic.add
      code: bash 
      computer: localhost
```
This has the strong advantage that we do not have to write our own logic to parse all the computer information and can use the well maintained CLI `verdi` from aiida to allow the user to create it before. It is in this PR because it was required for testing, but should be separated out in a different PR

### Current state of the code
Currently the code in the `workgraph.py` using different functions to create plugins that are not `ShellJob`s, and I am not sure if this is smart or not. It is a tradeoff between code duplications and flexibility, and requires a bit more thoughts and decisions how we go with this.