### PR TITLE
Remove the branch on main condition

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,8 +4,6 @@ name: Publish Python Package
 
 on:
   push:
-    # only pushes to main trigger
-    branches: [main]
     tags:
     - v[0-9]+.[0-9]+.[0-9]+*
 


### PR DESCRIPTION
I misinterpreted the `on` conditions to be connected logically by an `and`. I wanted that the workflow is only triggered when a tag is pushed to main. Instead the conditions or connected logically by an `or`, so every push to main will result in a the CI being triggered. We remove the condition to be the main branch since this is not really required.