### PR TITLE
Add parametrized tasks and data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 keywords = ["workflow"," icon", "aiida", "aiida-workgraph"]
 requires-python = '>=3.12'
 dependencies = [
+  "numpy",
   "isoduration",
   "pydantic",
   "pydantic-yaml",

--- a/src/sirocco/core.py
+++ b/src/sirocco/core.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Generic, Self, TypeVar
 
 from sirocco.parsing._yaml_data_models import (
     ConfigCycleTask,
-    ConfigCycleTaskDepend,
     ConfigCycleTaskInput,
+    ConfigCycleTaskWaitOn,
     ConfigTask,
     ConfigWorkflow,
     load_workflow_config,
@@ -19,13 +19,13 @@ if TYPE_CHECKING:
 
     from sirocco.parsing._yaml_data_models import ConfigCycle, DataBaseModel
 
-    type ConfigCycleSpec = ConfigCycleTaskDepend | ConfigCycleTaskInput
+    type ConfigCycleSpec = ConfigCycleTaskWaitOn | ConfigCycleTaskInput
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-TimeSeriesObject = TypeVar("TimeSeriesObject")
+StoreObject = TypeVar("StoreObject")
 
 
 class BaseNode:
@@ -69,7 +69,7 @@ class Task(BaseNode):
         inputs: list[Data] = []
         for input_spec in task_ref.inputs:
             inputs.extend(data for data in workflow.data.iter_from_cycle_spec(input_spec, date) if data is not None)
-        outputs: list[Data] = [workflow.data[output_spec.name, date] for output_spec in task_ref.outputs]
+        outputs: list[Data] = [workflow.data[output_spec.name, {"date": date}] for output_spec in task_ref.outputs]
 
         new = cls(
             date=date,
@@ -80,7 +80,7 @@ class Task(BaseNode):
         )  # this works because dataclass has generated this init for us
 
         # Store for actual linking in link_wait_on_tasks() once all tasks are created
-        new._wait_on_specs = task_ref.depends  # noqa: SLF001 we don't have access to self in a dataclass
+        new._wait_on_specs = task_ref.wait_on  # noqa: SLF001 we don't have access to self in a dataclass
         #                                                     and setting an underscored attribute from
         #                                                     the class itself raises SLF001
 
@@ -126,94 +126,74 @@ class Cycle(BaseNode):
     date: datetime | None = None
 
 
-class TimeSeries(Generic[TimeSeriesObject]):
-    """Dictionnary of objects accessed by date, checking start and end dates"""
+class ParamSeries(Generic[StoreObject]):
+    """Dictionnary of objects accessed by arbitrary parameters"""
 
-    def __init__(self) -> None:
-        self.start_date: datetime | None = None
-        self.end_date: datetime | None = None
-        self._dict: dict[str:TimeSeriesObject] = {}
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._dims: set | None = None
+        self._axes: dict | None = None
+        self._dict: dict[tuple:StoreObject] | None = None
 
-    def __setitem__(self, date: datetime, data: TimeSeriesObject) -> None:
-        if date in self._dict:
-            msg = f"date {date} already used, cannot set twice"
-            raise KeyError(msg)
-        self._dict[date] = data
-        if self.start_date is None:
-            self.start_date = date
-            self.end_date = date
-        elif date < self.start_date:
-            self.start_date = date
-        elif date > self.end_date:
-            self.end_date = date
-
-    def __getitem__(self, date: datetime) -> TimeSeriesObject:
-        if self.start_date is None:
-            msg = "TimeSeries still empty, cannot access by date"
-            raise ValueError(msg)
-        if date < self.start_date or date > self.end_date:
-            item = next(iter(self._dict.values()))
+    def __setitem__(self, parameters: dict, value: StoreObject) -> None:
+        # First access: set axes and initialize dictionnary
+        param_keys = set(parameters.keys())
+        if self._dims is None:
+            self._dims = param_keys
+            self._axes = {k: set() for k in param_keys}
+            self._dict = {}
+        # check dimensions
+        elif self._dims != param_keys:
             msg = (
-                f"date {date} for item '{item.name}' is out of bounds [{self.start_date} - {self.end_date}], ignoring."
+                f"ParamSeries {self._name}: parameter keys {param_keys} don't match ParamSeries dimensions {self._dims}"
             )
-            logger.warning(msg)
-            return
-        if date not in self._dict:
-            item = next(iter(self._dict.values()))
-            msg = f"date {date} for item '{item.name}' not found"
             raise KeyError(msg)
-        return self._dict[date]
-
-    def values(self) -> Iterator[TimeSeriesObject]:
-        yield from self._dict.values()
-
-
-class Store(Generic[TimeSeriesObject]):
-    """Container for TimeSeries or unique data"""
-
-    def __init__(self):
-        self._dict: dict[str, TimeSeries | TimeSeriesObject] = {}
-
-    def __setitem__(self, key: str | tuple(str, datetime | None), value: TimeSeriesObject) -> None:
-        if isinstance(key, tuple):
-            name, date = key
-        else:
-            name, date = key, None
-        if name in self._dict:
-            if not isinstance(self._dict[name], TimeSeries):
-                msg = f"single entry {name} already set"
-                raise KeyError(msg)
-            if date is None:
-                msg = f"entry {name} is a TimeSeries, must be accessed by date"
-                raise KeyError(msg)
-            self._dict[name][date] = value
-        elif date is None:
-            self._dict[name] = value
-        else:
-            self._dict[name] = TimeSeries()
-            self._dict[name][date] = value
-
-    def __getitem__(self, key: str | tuple(str, datetime | None)) -> TimeSeriesObject:
-        if isinstance(key, tuple):
-            name, date = key
-        else:
-            name, date = key, None
-
-        if name not in self._dict:
-            msg = f"entry {name} not found in Store"
+        # Build internal key
+        # use the order of self._dims instead of param_keys to ensure reproducibility
+        key = tuple(parameters[dim] for dim in self._dims)
+        # Check if slot already taken
+        if key in self._dict:
+            msg = f"ParamSeries {self._name}: key {key} already used, cannot set item twice"
             raise KeyError(msg)
-        if isinstance(self._dict[name], TimeSeries):
-            if date is None:
-                msg = f"entry {name} is a TimeSeries, must be accessed by date"
-                raise KeyError(msg)
-            return self._dict[name][date]
-        if date is not None:
-            msg = f"entry {name} is not a TimeSeries, cannot be accessed by date"
+        # Store new axes values
+        for dim in self._dims:
+            self._axes[dim].add(parameters[dim])
+        # Set item
+        self._dict[key] = value
+
+    def __getitem__(self, parameters: dict) -> StoreObject:
+        if self._dims != (param_keys := set(parameters.keys())):
+            msg = (
+                f"ParamSeries {self._name}: parameter keys {param_keys} don't match ParamSeries dimensions {self._dims}"
+            )
             raise KeyError(msg)
-        return self._dict[name]
+        # use the order of self._dims instead of param_keys to ensure reproducibility
+        key = tuple(parameters[dim] for dim in self._dims)
+        return self._dict[key]
+
+    def iter_from_cycle_spec(self, spec: ConfigCycleSpec, ref_date: datetime | None = None) -> Iterator[StoreObject]:
+        # Check date references
+        if "date" not in self._dims and (spec.lag or spec.date):
+            msg = f"ParamSeries {self._name} has no date dimension, cannot be referenced by dates"
+            raise ValueError(msg)
+        if "date" in self._dims and ref_date is None and spec.date is []:
+            msg = f"ParamSeries {self._name} has a date dimension, must be referenced by dates"
+            raise ValueError(msg)
+        # Generate list of target item keys
+        keys = [()]
+        for dim in self._dims:
+            if dim == "date":
+                keys = [(*key, date) for key in keys for date in self._resolve_target_dates(spec, ref_date)]
+            elif dim in spec.parameters:
+                keys = [(*key, spec.parameters[dim]) for key in keys]
+            else:
+                keys = [(*key, item) for key in keys for item in self._axes[dim]]
+        # Yield items
+        for key in keys:
+            yield self._dict[key]
 
     @staticmethod
-    def _resolve_target_dates(spec, ref_date: datetime | None) -> Iterator[datetime]:
+    def _resolve_target_dates(spec: ConfigCycleSpec, ref_date: datetime | None) -> Iterator[datetime]:
         if not spec.lag and not spec.date:
             yield ref_date
         if spec.lag:
@@ -222,25 +202,85 @@ class Store(Generic[TimeSeriesObject]):
         if spec.date:
             yield from spec.date
 
-    def iter_from_cycle_spec(
-        self, spec: ConfigCycleSpec, ref_date: datetime | None = None
-    ) -> Iterator[TimeSeriesObject]:
-        name = spec.name
-        if isinstance(self._dict[name], TimeSeries):
-            if ref_date is None and spec.date is []:
-                msg = "TimeSeries object must be referenced by dates"
+    def values(self) -> Iterator[StoreObject]:
+        yield from self._dict.values()
+
+
+class Store(Generic[StoreObject]):
+    """Container for ParamSeries or unique items"""
+
+    def __init__(self):
+        self._dict: dict[str, ParamSeries | StoreObject] = {}
+
+    def __setitem__(self, key: str | tuple(str, dict | None), value: StoreObject) -> None:
+        if isinstance(key, tuple):
+            name, parameters = key
+            if "date" in parameters and parameters["date"] is None:
+                del parameters["date"]
+        else:
+            name, parameters = key, None
+        if name in self._dict:
+            if not isinstance(self._dict[name], ParamSeries):
+                msg = f"single entry {name} already set"
+                raise KeyError(msg)
+            if parameters is None:
+                msg = f"entry {name} is a ParamSeries, must be accessed by parameters"
+                raise KeyError(msg)
+            self._dict[name][parameters] = value
+        elif not parameters:
+            self._dict[name] = value
+        else:
+            self._dict[name] = ParamSeries(name)
+            self._dict[name][parameters] = value
+
+    def __getitem__(self, key: str | tuple(str, dict | None)) -> StoreObject:
+        if isinstance(key, tuple):
+            name, parameters = key
+            if "date" in parameters and parameters["date"] is None:
+                del parameters["date"]
+        else:
+            name, parameters = key, None
+        if name not in self._dict:
+            msg = f"entry {name} not found in Store"
+            raise KeyError(msg)
+        if isinstance(self._dict[name], ParamSeries):
+            if parameters is None:
+                msg = f"entry {name} is a ParamSeries, must be accessed by parameters"
+                raise KeyError(msg)
+            return self._dict[name][parameters]
+        if parameters:
+            msg = f"entry {name} is not a ParamSeries, cannot be accessed by parameters"
+            raise KeyError(msg)
+        return self._dict[name]
+
+    def iter_from_cycle_spec(self, spec: ConfigCycleSpec, ref_date: datetime | None = None) -> Iterator[StoreObject]:
+        # Check if target items should be querried at all
+        if (when := spec.when) is not None:
+            if ref_date is None:
+                msg = "Cannot use a `when` specification without a `ref_date`"
                 raise ValueError(msg)
-            for target_date in self._resolve_target_dates(spec, ref_date):
-                yield self._dict[name][target_date]
+            if (at := when.at) is not None and at != ref_date:
+                return
+            if (before := when.before) is not None and before <= ref_date:
+                return
+            if (after := when.after) is not None and after >= ref_date:
+                return
+        # Yield items
+        name = spec.name
+        if isinstance(self._dict[name], ParamSeries):
+            yield from self._dict[name].iter_from_cycle_spec(spec, ref_date)
         else:
             if spec.lag or spec.date:
-                msg = f"item {name} is not a TimeSeries, cannot be referenced via date or lag"
+                msg = f"item {name} is not a ParamSeries, cannot be referenced by date or lag"
+                raise ValueError(msg)
+            if spec.parameters:
+                msg = f"item {name} is not a ParamSeries, cannot be referenced by parameters"
                 raise ValueError(msg)
             yield self._dict[name]
 
-    def values(self) -> Iterator[TimeSeriesObject]:
+    def values(self) -> Iterator[StoreObject]:
         for item in self._dict.values():
-            if isinstance(item, TimeSeries):
+            if isinstance(item, ParamSeries):
                 yield from item.values()
             else:
                 yield item
@@ -266,7 +306,7 @@ class Workflow:
                     for data_ref in task_ref.outputs:
                         data_name = data_ref.name
                         data_config = workflow_config.data_dict[data_name]
-                        self.data[data_name, date] = Data.from_config(data_config, date=date)
+                        self.data[data_name, {"date": date}] = Data.from_config(data_config, date=date)
 
         # 3 - create cycles and tasks
         for cycle_config in workflow_config.cycles:
@@ -276,11 +316,12 @@ class Workflow:
                 for task_ref in cycle_config.tasks:
                     task_name = task_ref.name
                     task_config = workflow_config.task_dict[task_name]
-                    self.tasks[task_name, date] = (
+                    task = Task.from_config(task_config, task_ref, workflow=self, date=date)
+                    self.tasks[task_name, {"date": date}] = (
                         task := Task.from_config(task_config, task_ref, workflow=self, date=date)
                     )
                     cycle_tasks.append(task)
-                self.cycles[cycle_name, date] = Cycle(name=cycle_name, tasks=cycle_tasks, date=date)
+                self.cycles[cycle_name, {"date": date}] = Cycle(name=cycle_name, tasks=cycle_tasks, date=date)
 
         # 4 - Link wait on tasks
         for task in self.tasks.values():

--- a/src/sirocco/core.py
+++ b/src/sirocco/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Any, Self
 
 from sirocco.parsing._yaml_data_models import (
     ConfigCycleTask,
@@ -14,7 +14,7 @@ from sirocco.parsing._yaml_data_models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from datetime import datetime
 
     from sirocco.parsing._yaml_data_models import ConfigCycle, DataBaseModel
@@ -25,23 +25,31 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-StoreObject = TypeVar("StoreObject")
-
-
+@dataclass
 class BaseNode:
     name: str
     color: str
+    parameters: dict = field(default_factory=dict)
+
+    @classmethod
+    def parameters_combinations(cls, config_parameters: dict, workflow_parameters: dict, date: datetime) -> list[dict]:
+        parameters_list = [{} if date is None else {'date': date}]
+        for param_name in config_parameters:
+            parameters_list = [parameters | {param_name: value} for parameters in parameters_list
+                               for value in workflow_parameters[param_name]]
+        return parameters_list
 
 
 @dataclass
 class Task(BaseNode):
-    name: str
-    workflow: Workflow
+    """Internal representation of a task node"""
+
+    color: str = "light_red"
+    workflow: Workflow | None = None
     outputs: list[Data] = field(default_factory=list)
     inputs: list[Data] = field(default_factory=list)
     wait_on: list[Task] = field(default_factory=list)
-    date: datetime | None = None
-    color: str = "light_red"
+    parameters: dict = field(default_factory=dict)
     # TODO: This list is too long. We should start with the set of supported
     #       keywords and extend it as we support more
     command: str | None = None
@@ -62,35 +70,45 @@ class Task(BaseNode):
     def from_config(
         cls,
         config: ConfigTask,
-        task_ref: ConfigCycleTask,
+        workflow_parameters: dict[str: Iterable],
+        graph_spec: ConfigCycleTask,
         workflow: Workflow,
+        *,
         date: datetime | None = None,
-    ) -> Self:
-        inputs: list[Data] = []
-        for input_spec in task_ref.inputs:
-            inputs.extend(data for data in workflow.data.iter_from_cycle_spec(input_spec, date) if data is not None)
-        outputs: list[Data] = [workflow.data[output_spec.name, {"date": date}] for output_spec in task_ref.outputs]
+    ) -> Iterator[Self]:
 
-        new = cls(
-            date=date,
-            inputs=inputs,
-            outputs=outputs,
-            workflow=workflow,
-            **dict(config),  # use the fact that pydantic models can be turned into dicts easily
-        )  # this works because dataclass has generated this init for us
+        for parameters in cls.parameters_combinations(config.parameters, workflow_parameters, date):
 
-        # Store for actual linking in link_wait_on_tasks() once all tasks are created
-        new._wait_on_specs = task_ref.wait_on  # noqa: SLF001 we don't have access to self in a dataclass
-        #                                                     and setting an underscored attribute from
-        #                                                     the class itself raises SLF001
+            inputs: list[Data] = []
+            for input_spec in graph_spec.inputs:
+                inputs.extend(data for data in workflow.data.iter_from_cycle_spec(input_spec, parameters) if data is not None)
 
-        return new
+            outputs: list[Data] = [workflow.data[output_spec.name, parameters] for output_spec in graph_spec.outputs]
+
+            # use the fact that pydantic models can be turned into dicts easily
+            cls_config = dict(config)
+            del(cls_config["parameters"])
+
+            new = cls(
+                parameters=parameters,
+                inputs=inputs,
+                outputs=outputs,
+                workflow=workflow,
+                **cls_config,
+            )  # this works because dataclass has generated this init for us
+
+            # Store for actual linking in link_wait_on_tasks() once all tasks are created
+            new._wait_on_specs = graph_spec.wait_on  # noqa: SLF001 we don't have access to self in a dataclass
+            #                                                and setting an underscored attribute from
+            #                                                the class itself raises SLF001
+
+            yield new
 
     def link_wait_on_tasks(self):
         self.wait_on: list[Task] = []
         for wait_on_spec in self._wait_on_specs:
             self.wait_on.extend(
-                task for task in self.workflow.tasks.iter_from_cycle_spec(wait_on_spec, self.date) if task is not None
+                task for task in self.workflow.tasks.iter_from_cycle_spec(wait_on_spec, self.parameters) if task is not None
             )
 
 
@@ -99,21 +117,21 @@ class Data(BaseNode):
     """Internal representation of a data node"""
 
     color: str = "light_blue"
-    name: str
     type: str
     src: str
     available: bool
-    date: datetime | None = None
+    parameters: dict = field(default_factory=dict)
 
     @classmethod
-    def from_config(cls, config: DataBaseModel, *, date: datetime | None = None):
-        return cls(
-            name=config.name,
-            type=config.type,
-            src=config.src,
-            available=config.available,
-            date=date,
-        )
+    def from_config(cls, config: DataBaseModel, workflow_parameters: dict[str: Iterable], *, date: datetime | None = None) -> Iterator[Self]:
+        for parameters in cls.parameters_combinations(config.parameters, workflow_parameters, date):
+            yield cls(
+                name=config.name,
+                type=config.type,
+                src=config.src,
+                available=config.available,
+                parameters=parameters,
+            )
 
 
 @dataclass(kw_only=True)
@@ -121,21 +139,19 @@ class Cycle(BaseNode):
     """Internal reprenstation of a cycle"""
 
     color: str = "light_green"
-    name: str
     tasks: list[Task]
-    date: datetime | None = None
 
 
-class ParamSeries(Generic[StoreObject]):
+class ParamSeries:
     """Dictionnary of objects accessed by arbitrary parameters"""
 
     def __init__(self, name: str) -> None:
         self._name = name
         self._dims: set | None = None
         self._axes: dict | None = None
-        self._dict: dict[tuple:StoreObject] | None = None
+        self._dict: dict[tuple:BaseNode] | None = None
 
-    def __setitem__(self, parameters: dict, value: StoreObject) -> None:
+    def __setitem__(self, parameters: dict, value: BaseNode) -> None:
         # First access: set axes and initialize dictionnary
         param_keys = set(parameters.keys())
         if self._dims is None:
@@ -161,7 +177,7 @@ class ParamSeries(Generic[StoreObject]):
         # Set item
         self._dict[key] = value
 
-    def __getitem__(self, parameters: dict) -> StoreObject:
+    def __getitem__(self, parameters: dict) -> BaseNode:
         if self._dims != (param_keys := set(parameters.keys())):
             msg = (
                 f"ParamSeries {self._name}: parameter keys {param_keys} don't match ParamSeries dimensions {self._dims}"
@@ -171,80 +187,78 @@ class ParamSeries(Generic[StoreObject]):
         key = tuple(parameters[dim] for dim in self._dims)
         return self._dict[key]
 
-    def iter_from_cycle_spec(self, spec: ConfigCycleSpec, ref_date: datetime | None = None) -> Iterator[StoreObject]:
+    def iter_from_cycle_spec(self, spec: ConfigCycleSpec, ref_params: dict) -> Iterator[BaseNode]:
         # Check date references
         if "date" not in self._dims and (spec.lag or spec.date):
             msg = f"ParamSeries {self._name} has no date dimension, cannot be referenced by dates"
             raise ValueError(msg)
-        if "date" in self._dims and ref_date is None and spec.date is []:
+        if "date" in self._dims and ref_params.get("date") is None and spec.date is []:
             msg = f"ParamSeries {self._name} has a date dimension, must be referenced by dates"
             raise ValueError(msg)
         # Generate list of target item keys
         keys = [()]
         for dim in self._dims:
-            if dim == "date":
-                keys = [(*key, date) for key in keys for date in self._resolve_target_dates(spec, ref_date)]
-            elif dim in spec.parameters:
-                keys = [(*key, spec.parameters[dim]) for key in keys]
-            else:
-                keys = [(*key, item) for key in keys for item in self._axes[dim]]
+            keys = [(*key, item) for key in keys for item in self._resolve_target_dim(spec, dim, ref_params)]
         # Yield items
         for key in keys:
             yield self._dict[key]
 
-    @staticmethod
-    def _resolve_target_dates(spec: ConfigCycleSpec, ref_date: datetime | None) -> Iterator[datetime]:
-        if not spec.lag and not spec.date:
-            yield ref_date
-        if spec.lag:
-            for lag in spec.lag:
-                yield ref_date + lag
-        if spec.date:
-            yield from spec.date
+    def _resolve_target_dim(self, spec: ConfigCycleSpec, dim: str, ref_params: Any) -> Iterator[Any]:
+        if dim == 'date':
+            if not spec.lag and not spec.date:
+                yield ref_params['date']
+            if spec.lag:
+                for lag in spec.lag:
+                    yield ref_params['date'] + lag
+            if spec.date:
+                yield from spec.date
+        elif spec.parameters.get(dim) == 'single':
+            yield ref_params[dim]
+        else:
+            yield from self._axes[dim]
 
-    def values(self) -> Iterator[StoreObject]:
+    def values(self) -> Iterator[BaseNode]:
         yield from self._dict.values()
 
 
-class Store(Generic[StoreObject]):
+class Store(BaseNode):
     """Container for ParamSeries or unique items"""
 
     def __init__(self):
-        self._dict: dict[str, ParamSeries | StoreObject] = {}
+        self._dict: dict[str, ParamSeries | BaseNode] = {}
 
-    def __setitem__(self, key: str | tuple(str, dict | None), value: StoreObject) -> None:
-        if isinstance(key, tuple):
-            name, parameters = key
-            if "date" in parameters and parameters["date"] is None:
-                del parameters["date"]
-        else:
-            name, parameters = key, None
+    def add(self, item) -> None:
+        if not hasattr(item, "parameters") or not hasattr(item, "name"):
+            msg = "items in a Store must have 'parameters' and 'name' attributes"
+            raise ValueError(msg)
+        name, parameters = item.name, item.parameters
+
         if name in self._dict:
             if not isinstance(self._dict[name], ParamSeries):
                 msg = f"single entry {name} already set"
                 raise KeyError(msg)
-            if parameters is None:
+            if not parameters:
                 msg = f"entry {name} is a ParamSeries, must be accessed by parameters"
                 raise KeyError(msg)
-            self._dict[name][parameters] = value
+            self._dict[name][parameters] = item
         elif not parameters:
-            self._dict[name] = value
+            self._dict[name] = item
         else:
             self._dict[name] = ParamSeries(name)
-            self._dict[name][parameters] = value
+            self._dict[name][parameters] = item
 
-    def __getitem__(self, key: str | tuple(str, dict | None)) -> StoreObject:
+    def __getitem__(self, key: str | tuple(str, dict)) -> BaseNode:
         if isinstance(key, tuple):
             name, parameters = key
             if "date" in parameters and parameters["date"] is None:
                 del parameters["date"]
         else:
-            name, parameters = key, None
+            name, parameters = key, {}
         if name not in self._dict:
             msg = f"entry {name} not found in Store"
             raise KeyError(msg)
         if isinstance(self._dict[name], ParamSeries):
-            if parameters is None:
+            if not parameters:
                 msg = f"entry {name} is a ParamSeries, must be accessed by parameters"
                 raise KeyError(msg)
             return self._dict[name][parameters]
@@ -253,11 +267,13 @@ class Store(Generic[StoreObject]):
             raise KeyError(msg)
         return self._dict[name]
 
-    def iter_from_cycle_spec(self, spec: ConfigCycleSpec, ref_date: datetime | None = None) -> Iterator[StoreObject]:
+    def iter_from_cycle_spec(self, spec: ConfigCycleSpec, ref_params: dict = None) -> Iterator[BaseNode]:
         # Check if target items should be querried at all
+        if ref_params is None:
+            ref_params = {}
         if (when := spec.when) is not None:
-            if ref_date is None:
-                msg = "Cannot use a `when` specification without a `ref_date`"
+            if (ref_date := ref_params.get('date')) is None:
+                msg = "Cannot use a `when` specification without a `reference date`"
                 raise ValueError(msg)
             if (at := when.at) is not None and at != ref_date:
                 return
@@ -268,7 +284,7 @@ class Store(Generic[StoreObject]):
         # Yield items
         name = spec.name
         if isinstance(self._dict[name], ParamSeries):
-            yield from self._dict[name].iter_from_cycle_spec(spec, ref_date)
+            yield from self._dict[name].iter_from_cycle_spec(spec, ref_params)
         else:
             if spec.lag or spec.date:
                 msg = f"item {name} is not a ParamSeries, cannot be referenced by date or lag"
@@ -278,7 +294,7 @@ class Store(Generic[StoreObject]):
                 raise ValueError(msg)
             yield self._dict[name]
 
-    def values(self) -> Iterator[StoreObject]:
+    def values(self) -> Iterator[BaseNode]:
         for item in self._dict.values():
             if isinstance(item, ParamSeries):
                 yield from item.values()
@@ -297,7 +313,8 @@ class Workflow:
 
         # 1 - create availalbe data nodes
         for data_config in workflow_config.data.available:
-            self.data[data_config.name] = Data.from_config(data_config, date=None)
+            for data in Data.from_config(data_config, workflow_config.parameters, date=None):
+                self.data.add(data)
 
         # 2 - create output data nodes
         for cycle_config in workflow_config.cycles:
@@ -306,28 +323,30 @@ class Workflow:
                     for data_ref in task_ref.outputs:
                         data_name = data_ref.name
                         data_config = workflow_config.data_dict[data_name]
-                        self.data[data_name, {"date": date}] = Data.from_config(data_config, date=date)
+                        for data in Data.from_config(data_config, workflow_config.parameters, date=date):
+                            self.data.add(data)
 
         # 3 - create cycles and tasks
         for cycle_config in workflow_config.cycles:
             cycle_name = cycle_config.name
             for date in self.cycle_dates(cycle_config):
                 cycle_tasks = []
-                for task_ref in cycle_config.tasks:
-                    task_name = task_ref.name
+                for task_graph_spec in cycle_config.tasks:
+                    task_name = task_graph_spec.name
                     task_config = workflow_config.task_dict[task_name]
-                    task = Task.from_config(task_config, task_ref, workflow=self, date=date)
-                    self.tasks[task_name, {"date": date}] = (
-                        task := Task.from_config(task_config, task_ref, workflow=self, date=date)
-                    )
-                    cycle_tasks.append(task)
-                self.cycles[cycle_name, {"date": date}] = Cycle(name=cycle_name, tasks=cycle_tasks, date=date)
+                    # CONTINUE HERE
+                    for task in Task.from_config(task_config, workflow_config.parameters, task_graph_spec, workflow=self, date=date):
+                        self.tasks.add(task)
+                        cycle_tasks.append(task)
+                parameters = {} if date is None else {'date':date}
+                self.cycles.add(Cycle(name=cycle_name, tasks=cycle_tasks, parameters=parameters))
 
         # 4 - Link wait on tasks
         for task in self.tasks.values():
             task.link_wait_on_tasks()
 
-    def cycle_dates(self, cycle_config: ConfigCycle) -> Iterator[datetime]:
+    @staticmethod
+    def cycle_dates(cycle_config: ConfigCycle) -> Iterator[datetime]:
         yield (date := cycle_config.start_date)
         if cycle_config.period is not None:
             while (date := date + cycle_config.period) < cycle_config.end_date:

--- a/src/sirocco/core.py
+++ b/src/sirocco/core.py
@@ -195,13 +195,6 @@ class NodeArray:
         if "date" in self._dims and reference.get("date") is None and spec.date is []:
             msg = f"NodeArray {self._name} has a date dimension, must be referenced by dates"
             raise ValueError(msg)
-        # # Generate list of target item keys
-        # keys = [()]
-        # for dim in self._dims:
-        #     keys = [(*key, item) for key in keys for item in self._resolve_target_dim(spec, dim, reference)]
-        # # Yield items
-        # for key in keys:
-        #     yield self._dict[key]
 
         for key in product(*(self._resolve_target_dim(spec, dim, reference) for dim in self._dims)):
             yield self._dict[key]

--- a/src/sirocco/core.py
+++ b/src/sirocco/core.py
@@ -15,7 +15,7 @@ from sirocco.parsing._yaml_data_models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterator
     from datetime import datetime
 
     from sirocco.parsing._yaml_data_models import ConfigCycle, DataBaseModel
@@ -69,7 +69,7 @@ class Task(BaseGraphItem):
     def from_config(
         cls,
         config: ConfigTask,
-        workflow_parameters: dict[str, Iterable],
+        workflow_parameters: dict[str, list],
         graph_spec: ConfigCycleTask,
         workflow: Workflow,
         *,
@@ -124,7 +124,7 @@ class Data(BaseGraphItem):
 
     @classmethod
     def from_config(
-        cls, config: DataBaseModel, workflow_parameters: dict[str, Iterable], *, date: datetime | None = None
+        cls, config: DataBaseModel, workflow_parameters: dict[str, list], *, date: datetime | None = None
     ) -> Iterator[Self]:
         for coordinates in cls.iter_coordinates(config.parameters, workflow_parameters, date):
             yield cls(

--- a/src/sirocco/core.py
+++ b/src/sirocco/core.py
@@ -73,7 +73,7 @@ class Task(BaseNode):
     def from_config(
         cls,
         config: ConfigTask,
-        workflow_parameters: dict[str:Iterable],
+        workflow_parameters: dict[str, Iterable],
         graph_spec: ConfigCycleTask,
         workflow: Workflow,
         *,
@@ -129,7 +129,7 @@ class Data(BaseNode):
 
     @classmethod
     def from_config(
-        cls, config: DataBaseModel, workflow_parameters: dict[str:Iterable], *, date: datetime | None = None
+        cls, config: DataBaseModel, workflow_parameters: dict[str, Iterable], *, date: datetime | None = None
     ) -> Iterator[Self]:
         for parameters in cls.parameters_combinations(config.parameters, workflow_parameters, date):
             yield cls(
@@ -156,7 +156,7 @@ class ParamSeries:
         self._name = name
         self._dims: set | None = None
         self._axes: dict | None = None
-        self._dict: dict[tuple:BaseNode] | None = None
+        self._dict: dict[tuple, BaseNode] | None = None
 
     def __setitem__(self, parameters: dict, value: BaseNode) -> None:
         # First access: set axes and initialize dictionnary
@@ -254,7 +254,7 @@ class Store(BaseNode):
             self._dict[name] = ParamSeries(name)
             self._dict[name][parameters] = item
 
-    def __getitem__(self, key: str | tuple(str, dict)) -> BaseNode:
+    def __getitem__(self, key: str | tuple[str, dict]) -> BaseNode:
         if isinstance(key, tuple):
             name, parameters = key
             if "date" in parameters and parameters["date"] is None:

--- a/src/sirocco/core.py
+++ b/src/sirocco/core.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Self
 from itertools import product
+from typing import TYPE_CHECKING, Any, Self
 
 from sirocco.parsing._yaml_data_models import (
     ConfigCycleTask,
@@ -160,9 +160,7 @@ class NodeArray:
             self._dict = {}
         # check dimensions
         elif self._dims != input_dims:
-            msg = (
-                f"NodeArray {self._name}: coordinate names {input_dims} don't match NodeArray dimensions {self._dims}"
-            )
+            msg = f"NodeArray {self._name}: coordinate names {input_dims} don't match NodeArray dimensions {self._dims}"
             raise KeyError(msg)
         # Build internal key
         # use the order of self._dims instead of param_keys to ensure reproducibility
@@ -179,9 +177,7 @@ class NodeArray:
 
     def __getitem__(self, coordinates: dict) -> BaseNode:
         if self._dims != (input_dims := tuple(coordinates.keys())):
-            msg = (
-                f"NodeArray {self._name}: coordinate names {input_dims} don't match NodeArray dimensions {self._dims}"
-            )
+            msg = f"NodeArray {self._name}: coordinate names {input_dims} don't match NodeArray dimensions {self._dims}"
             raise KeyError(msg)
         # use the order of self._dims instead of param_keys to ensure reproducibility
         key = tuple(coordinates[dim] for dim in self._dims)

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -196,8 +196,8 @@ class ConfigGeneratedData(DataBaseModel):
 class ConfigData(BaseModel):
     """To create the container of available and generated data"""
 
-    available: list[ConfigAvailableData] | None = None
-    generated: list[ConfigGeneratedData]
+    available: list[ConfigAvailableData] = []
+    generated: list[ConfigGeneratedData] = []
 
 
 class ConfigCycleTaskWaitOn(_NamedBaseModel, _LagDateBaseModel):

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -116,7 +116,7 @@ class _LagDateBaseModel(BaseModel):
             return {}
         for k, v in params.items():
             if v not in ("single", "all"):
-                msg = "parameter reference can only be 'single' or 'all'"
+                msg = f"parameter {k}: reference can only be 'single' or 'all', got {v}"
                 raise ValueError(msg)
         return params
 

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -75,9 +75,9 @@ class PrettyPrinter:
         return str(obj)
 
     @format.register
-    def format_basic(self, obj: core.BaseNode) -> str:
+    def format_basic(self, obj: core.BaseGraphItem) -> str:
         """
-        Default formatting for BaseNode.
+        Default formatting for BaseGraphItem.
 
         Can also be used explicitly to get a single line representation of any node.
 

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -86,17 +86,21 @@ class PrettyPrinter:
         >>> from datetime import datetime
         >>> print(
         ...     PrettyPrinter().format_basic(
-        ...         Task(name=foo, date=datetime(1000, 1, 1).date(), workflow=None)
+        ...         Task(name=foo, parameters={'date': datetime(1000, 1, 1).date()}, workflow=None)
         ...     )
         ... )
         foo [1000-01-01]
         """
         name = obj.name
-        date = f"[{obj.date}]" if obj.date else None
+        if obj.parameters:
+            params = ", ".join([f"{name}: {value}" for name, value in obj.parameters.items()])
+            params = f"[{params}]"
+        else:
+            params = None
         if self.colors:
             name = colored(name, obj.color, attrs=["bold"])
-            date = colored(date, obj.color) if date else None
-        return f"{name} {date}" if date else name
+            params = colored(params, obj.color) if params else None
+        return f"{name} {params}" if params else name
 
     @format.register
     def format_workflow(self, obj: core.Workflow) -> str:

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -88,7 +88,7 @@ class PrettyPrinter:
         ...     PrettyPrinter().format_basic(
         ...         Task(
         ...             name=foo,
-        ...             parameters={"date": datetime(1000, 1, 1).date()},
+        ...             coordinates={"date": datetime(1000, 1, 1).date()},
         ...             workflow=None,
         ...         )
         ...     )
@@ -96,19 +96,19 @@ class PrettyPrinter:
         foo [1000-01-01]
         """
         name = obj.name
-        if obj.parameters:
-            params = ", ".join([f"{name}: {value}" for name, value in obj.parameters.items()])
-            params = f"[{params}]"
+        if obj.coordinates:
+            coords = ", ".join([f"{name}: {value}" for name, value in obj.coordinates.items()])
+            coords = f"[{coords}]"
         else:
-            params = None
+            coords = None
         if self.colors:
             name = colored(name, obj.color, attrs=["bold"])
-            params = colored(params, obj.color) if params else None
-        return f"{name} {params}" if params else name
+            coords = colored(coords, obj.color) if coords else None
+        return f"{name} {coords}" if coords else name
 
     @format.register
     def format_workflow(self, obj: core.Workflow) -> str:
-        cycles = "\n".join(self.format(cycle) for cycle in obj.cycles.values())
+        cycles = "\n".join(self.format(cycle) for cycle in obj.cycles)
         return self.as_block("cycles", cycles)
 
     @format.register

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -86,7 +86,11 @@ class PrettyPrinter:
         >>> from datetime import datetime
         >>> print(
         ...     PrettyPrinter().format_basic(
-        ...         Task(name=foo, parameters={'date': datetime(1000, 1, 1).date()}, workflow=None)
+        ...         Task(
+        ...             name=foo,
+        ...             parameters={"date": datetime(1000, 1, 1).date()},
+        ...             workflow=None,
+        ...         )
         ...     )
         ... )
         foo [1000-01-01]

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -75,9 +75,9 @@ class PrettyPrinter:
         return str(obj)
 
     @format.register
-    def format_basic(self, obj: core.BaseGraphItem) -> str:
+    def format_basic(self, obj: core.GraphItem) -> str:
         """
-        Default formatting for BaseGraphItem.
+        Default formatting for GraphItem.
 
         Can also be used explicitly to get a single line representation of any node.
 

--- a/src/sirocco/vizgraph.py
+++ b/src/sirocco/vizgraph.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from colorsys import hsv_to_rgb
+from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
-from itertools import chain
 
 from lxml import etree
 from pygraphviz import AGraph
@@ -53,7 +53,9 @@ class VizGraph:
             cluster_nodes = []
             for task_node in cycle.tasks:
                 cluster_nodes.append(task_node)
-                self.agraph.add_node(task_node, label=task_node.name, tooltip=self.tooltip(task_node), **self.task_node_kw)
+                self.agraph.add_node(
+                    task_node, label=task_node.name, tooltip=self.tooltip(task_node), **self.task_node_kw
+                )
                 for data_node in task_node.inputs:
                     self.agraph.add_edge(data_node, task_node, **self.io_edge_kw)
                 for data_node in task_node.outputs:
@@ -73,7 +75,7 @@ class VizGraph:
 
     @staticmethod
     def tooltip(node) -> str:
-        return '\n'.join(chain([node.name], (f"  {k}: {v}" for k, v in node.coordinates.items())))
+        return "\n".join(chain([node.name], (f"  {k}: {v}" for k, v in node.coordinates.items())))
 
     def draw(self, **kwargs):
         # draw graphviz dot graph to svg file

--- a/src/sirocco/vizgraph.py
+++ b/src/sirocco/vizgraph.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from colorsys import hsv_to_rgb
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
+from itertools import chain
 
 from lxml import etree
 from pygraphviz import AGraph
@@ -41,20 +42,18 @@ class VizGraph:
     def __init__(self, name: str, cycles: Store, data: Store) -> None:
         self.name = name
         self.agraph = AGraph(name=name, fontname="Fira Sans", newrank=True)
-        for data_node in data.values():
+        for data_node in data:
             gv_kw = self.data_av_node_kw if data_node.available else self.data_gen_node_kw
-            tooltip = data_node.name if data_node.date is None else f"{data_node.name}\n {data_node.date}"
-            self.agraph.add_node(data_node, tooltip=tooltip, label=data_node.name, **gv_kw)
+            self.agraph.add_node(data_node, tooltip=self.tooltip(data_node), label=data_node.name, **gv_kw)
 
         k = 1
-        for cycle in cycles.values():
+        for cycle in cycles:
             # NOTE: For some reason, clusters need to have a unique name that starts with 'cluster'
             #       otherwise they are not taken into account. Hence the k index.
             cluster_nodes = []
             for task_node in cycle.tasks:
                 cluster_nodes.append(task_node)
-                tooltip = task_node.name if task_node.date is None else f"{task_node.name}\n {task_node.date}"
-                self.agraph.add_node(task_node, label=task_node.name, tooltip=tooltip, **self.task_node_kw)
+                self.agraph.add_node(task_node, label=task_node.name, tooltip=self.tooltip(task_node), **self.task_node_kw)
                 for data_node in task_node.inputs:
                     self.agraph.add_edge(data_node, task_node, **self.io_edge_kw)
                 for data_node in task_node.outputs:
@@ -62,18 +61,19 @@ class VizGraph:
                     cluster_nodes.append(data_node)
                 for wait_task_node in task_node.wait_on:
                     self.agraph.add_edge(wait_task_node, task_node, **self.wait_on_edge_kw)
-            cluster_label = cycle.name
-            if cycle.date is not None:
-                cluster_label += "\n" + cycle.date.isoformat()
             self.agraph.add_subgraph(
                 cluster_nodes,
                 name=f"cluster_{cycle.name}_{k}",
                 clusterrank="global",
-                label=cluster_label,
-                tooltip=cluster_label,
+                label=self.tooltip(cycle),
+                tooltip=self.tooltip(cycle),
                 **self.cluster_kw,
             )
             k += 1
+
+    @staticmethod
+    def tooltip(node) -> str:
+        return '\n'.join(chain([node.name], (f"  {k}: {v}" for k, v in node.coordinates.items())))
 
     def draw(self, **kwargs):
         # draw graphviz dot graph to svg file

--- a/tests/files/configs/test_config_large.yml
+++ b/tests/files/configs/test_config_large.yml
@@ -17,17 +17,17 @@ cycles:
             outputs: [icon_input]
             wait_on:
               - icon:
-                  lag: '-P4M'
                   when:
                     after: '2025-03-01T00:00'
+                  lag: '-P4M'
         - icon:
             inputs:
               - grid_file
               - icon_input
               - icon_restart:
-                  lag: '-P2M'
                   when:
                     after: *root_start_date
+                  lag: '-P2M'
             outputs: [stream_1, stream_2, icon_restart]
         - postproc_1:
             inputs: [stream_1]

--- a/tests/files/configs/test_config_large.yml
+++ b/tests/files/configs/test_config_large.yml
@@ -10,20 +10,24 @@ cycles:
   - icon_bimonthly:
       start_date: *root_start_date
       end_date: *root_end_date
-      period: P2M
+      period: 'P2M'
       tasks:
         - preproc:
             inputs: [grid_file, extpar_file, ERA5]
             outputs: [icon_input]
-            depends:
+            wait_on:
               - icon:
-                  lag: -P4M
+                  lag: '-P4M'
+                  when:
+                    after: '2025-03-01T00:00'
         - icon:
             inputs:
               - grid_file
               - icon_input
               - icon_restart:
                   lag: '-P2M'
+                  when:
+                    after: *root_start_date
             outputs: [stream_1, stream_2, icon_restart]
         - postproc_1:
             inputs: [stream_1]
@@ -34,7 +38,7 @@ cycles:
   - yearly:
       start_date: *root_start_date
       end_date: *root_end_date
-      period: P1Y
+      period: 'P1Y'
       tasks:
         - postproc_2:
             inputs:

--- a/tests/files/configs/test_config_parameters.yml
+++ b/tests/files/configs/test_config_parameters.yml
@@ -1,0 +1,93 @@
+---
+start_date: &root_start_date '2026-01-01T00:00'
+end_date: &root_end_date '2028-01-01T00:00'
+
+cycles:
+  - bimonthly_tasks:
+      start_date: *root_start_date
+      end_date: *root_end_date
+      period: P2M
+      tasks:
+        - icon:
+            inputs:
+              - initial conditions:
+                  when:
+                    at: *root_start_date
+              - icon_restart:
+                  when:
+                    after: *root_start_date
+                  lag: -P2M
+                  parameters:
+                    foo: single
+                    bar: single
+              - forcing
+            outputs: [icon_output, icon_restart]
+        - statistics_foo:
+            inputs:
+              - icon_output:
+                  parameters:
+                    bar: single
+            outputs: [analysis_foo]
+        - statistics_foo_bar:
+            inputs: [analysis_foo]
+            outputs: [analysis_foo_bar]
+  - yearly:
+      start_date: *root_start_date
+      end_date: *root_end_date
+      period: P1Y
+      tasks:
+        - merge:
+            inputs:
+              - analysis_foo_bar:
+                  lag: ['P0M', 'P2M', 'P4M', 'P6M', 'P8M', 'P10M']
+            outputs: [yearly_analysis]
+
+tasks:
+  - icon:
+      plugin: shell
+      command: $PWD/tests/files/scripts/icon.py
+      input_arg_options:
+        icon_restart: '--restart'
+      parameters: [foo, bar]
+  - statistics_foo:
+      plugin: shell
+      command: $PWD/tests/files/scripts/statistics.py
+      parameters: [bar]
+  - statistics_foo_bar:
+      plugin: shell
+      command: $PWD/tests/files/scripts/statistics.py
+  - merge:
+      plugin: shell
+      command: $PWD/tests/files/scripts/merge.py
+
+data:
+  available:
+    - initial conditions:
+        type: file
+        src: .
+    - forcing:
+        type: file
+        src: .
+  generated:
+    - icon_output:
+        type: file
+        src: output
+        parameters: [foo, bar]
+    - icon_restart:
+        type: file
+        src: restart
+        parameters: [foo, bar]
+    - analysis_foo:
+        type: file
+        src: analysis_foo
+        parameters: [bar]
+    - analysis_foo_bar:
+        type: file
+        src: foo_analysis_bar
+    - yearly_analysis:
+        type: file
+        src: yearly_analysis
+
+parameters:
+  foo: [0, 1, 2]
+  bar: {arange: [3, 4, 0.5]}

--- a/tests/files/configs/test_config_parameters.yml
+++ b/tests/files/configs/test_config_parameters.yml
@@ -90,4 +90,4 @@ data:
 
 parameters:
   foo: [0, 1, 2]
-  bar: {arange: [3, 4, 0.5]}
+  bar: [3.0, 3.5]

--- a/tests/files/configs/test_config_small.yml
+++ b/tests/files/configs/test_config_small.yml
@@ -11,11 +11,13 @@ cycles:
             inputs:
               - icon_restart:
                   lag: -P2M
+                  when:
+                    after: *root_start_date
             outputs: [icon_output, icon_restart]
   - lastly:
       tasks:
         - cleanup:
-            depends:
+            wait_on:
               - icon:
                   date: 2026-05-01T00:00
 tasks:

--- a/tests/files/configs/test_config_small.yml
+++ b/tests/files/configs/test_config_small.yml
@@ -10,9 +10,9 @@ cycles:
         - icon:
             inputs:
               - icon_restart:
-                  lag: -P2M
                   when:
                     after: *root_start_date
+                  lag: -P2M
             outputs: [icon_output, icon_restart]
   - lastly:
       tasks:

--- a/tests/files/data/test_config_large.txt
+++ b/tests/files/data/test_config_large.txt
@@ -6,428 +6,428 @@ cycles:
               - obs_data
             output:
               - extpar_file
-  - icon_bimonthly [2025-01-01 00:00:00]:
+  - icon_bimonthly [date: 2025-01-01 00:00:00]:
       tasks:
-        - preproc [2025-01-01 00:00:00]:
+        - preproc [date: 2025-01-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2025-01-01 00:00:00]
-        - icon [2025-01-01 00:00:00]:
+              - icon_input [date: 2025-01-01 00:00:00]
+        - icon [date: 2025-01-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2025-01-01 00:00:00]
+              - icon_input [date: 2025-01-01 00:00:00]
             output:
-              - stream_1 [2025-01-01 00:00:00]
-              - stream_2 [2025-01-01 00:00:00]
-              - icon_restart [2025-01-01 00:00:00]
-        - postproc_1 [2025-01-01 00:00:00]:
+              - stream_1 [date: 2025-01-01 00:00:00]
+              - stream_2 [date: 2025-01-01 00:00:00]
+              - icon_restart [date: 2025-01-01 00:00:00]
+        - postproc_1 [date: 2025-01-01 00:00:00]:
             input:
-              - stream_1 [2025-01-01 00:00:00]
+              - stream_1 [date: 2025-01-01 00:00:00]
             output:
-              - postout_1 [2025-01-01 00:00:00]
-        - store_and_clean_1 [2025-01-01 00:00:00]:
+              - postout_1 [date: 2025-01-01 00:00:00]
+        - store_and_clean_1 [date: 2025-01-01 00:00:00]:
             input:
-              - postout_1 [2025-01-01 00:00:00]
-              - stream_1 [2025-01-01 00:00:00]
-              - icon_input [2025-01-01 00:00:00]
+              - postout_1 [date: 2025-01-01 00:00:00]
+              - stream_1 [date: 2025-01-01 00:00:00]
+              - icon_input [date: 2025-01-01 00:00:00]
             output:
-              - stored_data_1 [2025-01-01 00:00:00]
-  - icon_bimonthly [2025-03-01 00:00:00]:
+              - stored_data_1 [date: 2025-01-01 00:00:00]
+  - icon_bimonthly [date: 2025-03-01 00:00:00]:
       tasks:
-        - preproc [2025-03-01 00:00:00]:
+        - preproc [date: 2025-03-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2025-03-01 00:00:00]
-        - icon [2025-03-01 00:00:00]:
+              - icon_input [date: 2025-03-01 00:00:00]
+        - icon [date: 2025-03-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2025-03-01 00:00:00]
-              - icon_restart [2025-01-01 00:00:00]
+              - icon_input [date: 2025-03-01 00:00:00]
+              - icon_restart [date: 2025-01-01 00:00:00]
             output:
-              - stream_1 [2025-03-01 00:00:00]
-              - stream_2 [2025-03-01 00:00:00]
-              - icon_restart [2025-03-01 00:00:00]
-        - postproc_1 [2025-03-01 00:00:00]:
+              - stream_1 [date: 2025-03-01 00:00:00]
+              - stream_2 [date: 2025-03-01 00:00:00]
+              - icon_restart [date: 2025-03-01 00:00:00]
+        - postproc_1 [date: 2025-03-01 00:00:00]:
             input:
-              - stream_1 [2025-03-01 00:00:00]
+              - stream_1 [date: 2025-03-01 00:00:00]
             output:
-              - postout_1 [2025-03-01 00:00:00]
-        - store_and_clean_1 [2025-03-01 00:00:00]:
+              - postout_1 [date: 2025-03-01 00:00:00]
+        - store_and_clean_1 [date: 2025-03-01 00:00:00]:
             input:
-              - postout_1 [2025-03-01 00:00:00]
-              - stream_1 [2025-03-01 00:00:00]
-              - icon_input [2025-03-01 00:00:00]
+              - postout_1 [date: 2025-03-01 00:00:00]
+              - stream_1 [date: 2025-03-01 00:00:00]
+              - icon_input [date: 2025-03-01 00:00:00]
             output:
-              - stored_data_1 [2025-03-01 00:00:00]
-  - icon_bimonthly [2025-05-01 00:00:00]:
+              - stored_data_1 [date: 2025-03-01 00:00:00]
+  - icon_bimonthly [date: 2025-05-01 00:00:00]:
       tasks:
-        - preproc [2025-05-01 00:00:00]:
+        - preproc [date: 2025-05-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2025-05-01 00:00:00]
+              - icon_input [date: 2025-05-01 00:00:00]
             wait on:
-              - icon [2025-01-01 00:00:00]
-        - icon [2025-05-01 00:00:00]:
+              - icon [date: 2025-01-01 00:00:00]
+        - icon [date: 2025-05-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2025-05-01 00:00:00]
-              - icon_restart [2025-03-01 00:00:00]
+              - icon_input [date: 2025-05-01 00:00:00]
+              - icon_restart [date: 2025-03-01 00:00:00]
             output:
-              - stream_1 [2025-05-01 00:00:00]
-              - stream_2 [2025-05-01 00:00:00]
-              - icon_restart [2025-05-01 00:00:00]
-        - postproc_1 [2025-05-01 00:00:00]:
+              - stream_1 [date: 2025-05-01 00:00:00]
+              - stream_2 [date: 2025-05-01 00:00:00]
+              - icon_restart [date: 2025-05-01 00:00:00]
+        - postproc_1 [date: 2025-05-01 00:00:00]:
             input:
-              - stream_1 [2025-05-01 00:00:00]
+              - stream_1 [date: 2025-05-01 00:00:00]
             output:
-              - postout_1 [2025-05-01 00:00:00]
-        - store_and_clean_1 [2025-05-01 00:00:00]:
+              - postout_1 [date: 2025-05-01 00:00:00]
+        - store_and_clean_1 [date: 2025-05-01 00:00:00]:
             input:
-              - postout_1 [2025-05-01 00:00:00]
-              - stream_1 [2025-05-01 00:00:00]
-              - icon_input [2025-05-01 00:00:00]
+              - postout_1 [date: 2025-05-01 00:00:00]
+              - stream_1 [date: 2025-05-01 00:00:00]
+              - icon_input [date: 2025-05-01 00:00:00]
             output:
-              - stored_data_1 [2025-05-01 00:00:00]
-  - icon_bimonthly [2025-07-01 00:00:00]:
+              - stored_data_1 [date: 2025-05-01 00:00:00]
+  - icon_bimonthly [date: 2025-07-01 00:00:00]:
       tasks:
-        - preproc [2025-07-01 00:00:00]:
+        - preproc [date: 2025-07-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2025-07-01 00:00:00]
+              - icon_input [date: 2025-07-01 00:00:00]
             wait on:
-              - icon [2025-03-01 00:00:00]
-        - icon [2025-07-01 00:00:00]:
+              - icon [date: 2025-03-01 00:00:00]
+        - icon [date: 2025-07-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2025-07-01 00:00:00]
-              - icon_restart [2025-05-01 00:00:00]
+              - icon_input [date: 2025-07-01 00:00:00]
+              - icon_restart [date: 2025-05-01 00:00:00]
             output:
-              - stream_1 [2025-07-01 00:00:00]
-              - stream_2 [2025-07-01 00:00:00]
-              - icon_restart [2025-07-01 00:00:00]
-        - postproc_1 [2025-07-01 00:00:00]:
+              - stream_1 [date: 2025-07-01 00:00:00]
+              - stream_2 [date: 2025-07-01 00:00:00]
+              - icon_restart [date: 2025-07-01 00:00:00]
+        - postproc_1 [date: 2025-07-01 00:00:00]:
             input:
-              - stream_1 [2025-07-01 00:00:00]
+              - stream_1 [date: 2025-07-01 00:00:00]
             output:
-              - postout_1 [2025-07-01 00:00:00]
-        - store_and_clean_1 [2025-07-01 00:00:00]:
+              - postout_1 [date: 2025-07-01 00:00:00]
+        - store_and_clean_1 [date: 2025-07-01 00:00:00]:
             input:
-              - postout_1 [2025-07-01 00:00:00]
-              - stream_1 [2025-07-01 00:00:00]
-              - icon_input [2025-07-01 00:00:00]
+              - postout_1 [date: 2025-07-01 00:00:00]
+              - stream_1 [date: 2025-07-01 00:00:00]
+              - icon_input [date: 2025-07-01 00:00:00]
             output:
-              - stored_data_1 [2025-07-01 00:00:00]
-  - icon_bimonthly [2025-09-01 00:00:00]:
+              - stored_data_1 [date: 2025-07-01 00:00:00]
+  - icon_bimonthly [date: 2025-09-01 00:00:00]:
       tasks:
-        - preproc [2025-09-01 00:00:00]:
+        - preproc [date: 2025-09-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2025-09-01 00:00:00]
+              - icon_input [date: 2025-09-01 00:00:00]
             wait on:
-              - icon [2025-05-01 00:00:00]
-        - icon [2025-09-01 00:00:00]:
+              - icon [date: 2025-05-01 00:00:00]
+        - icon [date: 2025-09-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2025-09-01 00:00:00]
-              - icon_restart [2025-07-01 00:00:00]
+              - icon_input [date: 2025-09-01 00:00:00]
+              - icon_restart [date: 2025-07-01 00:00:00]
             output:
-              - stream_1 [2025-09-01 00:00:00]
-              - stream_2 [2025-09-01 00:00:00]
-              - icon_restart [2025-09-01 00:00:00]
-        - postproc_1 [2025-09-01 00:00:00]:
+              - stream_1 [date: 2025-09-01 00:00:00]
+              - stream_2 [date: 2025-09-01 00:00:00]
+              - icon_restart [date: 2025-09-01 00:00:00]
+        - postproc_1 [date: 2025-09-01 00:00:00]:
             input:
-              - stream_1 [2025-09-01 00:00:00]
+              - stream_1 [date: 2025-09-01 00:00:00]
             output:
-              - postout_1 [2025-09-01 00:00:00]
-        - store_and_clean_1 [2025-09-01 00:00:00]:
+              - postout_1 [date: 2025-09-01 00:00:00]
+        - store_and_clean_1 [date: 2025-09-01 00:00:00]:
             input:
-              - postout_1 [2025-09-01 00:00:00]
-              - stream_1 [2025-09-01 00:00:00]
-              - icon_input [2025-09-01 00:00:00]
+              - postout_1 [date: 2025-09-01 00:00:00]
+              - stream_1 [date: 2025-09-01 00:00:00]
+              - icon_input [date: 2025-09-01 00:00:00]
             output:
-              - stored_data_1 [2025-09-01 00:00:00]
-  - icon_bimonthly [2025-11-01 00:00:00]:
+              - stored_data_1 [date: 2025-09-01 00:00:00]
+  - icon_bimonthly [date: 2025-11-01 00:00:00]:
       tasks:
-        - preproc [2025-11-01 00:00:00]:
+        - preproc [date: 2025-11-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2025-11-01 00:00:00]
+              - icon_input [date: 2025-11-01 00:00:00]
             wait on:
-              - icon [2025-07-01 00:00:00]
-        - icon [2025-11-01 00:00:00]:
+              - icon [date: 2025-07-01 00:00:00]
+        - icon [date: 2025-11-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2025-11-01 00:00:00]
-              - icon_restart [2025-09-01 00:00:00]
+              - icon_input [date: 2025-11-01 00:00:00]
+              - icon_restart [date: 2025-09-01 00:00:00]
             output:
-              - stream_1 [2025-11-01 00:00:00]
-              - stream_2 [2025-11-01 00:00:00]
-              - icon_restart [2025-11-01 00:00:00]
-        - postproc_1 [2025-11-01 00:00:00]:
+              - stream_1 [date: 2025-11-01 00:00:00]
+              - stream_2 [date: 2025-11-01 00:00:00]
+              - icon_restart [date: 2025-11-01 00:00:00]
+        - postproc_1 [date: 2025-11-01 00:00:00]:
             input:
-              - stream_1 [2025-11-01 00:00:00]
+              - stream_1 [date: 2025-11-01 00:00:00]
             output:
-              - postout_1 [2025-11-01 00:00:00]
-        - store_and_clean_1 [2025-11-01 00:00:00]:
+              - postout_1 [date: 2025-11-01 00:00:00]
+        - store_and_clean_1 [date: 2025-11-01 00:00:00]:
             input:
-              - postout_1 [2025-11-01 00:00:00]
-              - stream_1 [2025-11-01 00:00:00]
-              - icon_input [2025-11-01 00:00:00]
+              - postout_1 [date: 2025-11-01 00:00:00]
+              - stream_1 [date: 2025-11-01 00:00:00]
+              - icon_input [date: 2025-11-01 00:00:00]
             output:
-              - stored_data_1 [2025-11-01 00:00:00]
-  - icon_bimonthly [2026-01-01 00:00:00]:
+              - stored_data_1 [date: 2025-11-01 00:00:00]
+  - icon_bimonthly [date: 2026-01-01 00:00:00]:
       tasks:
-        - preproc [2026-01-01 00:00:00]:
+        - preproc [date: 2026-01-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2026-01-01 00:00:00]
+              - icon_input [date: 2026-01-01 00:00:00]
             wait on:
-              - icon [2025-09-01 00:00:00]
-        - icon [2026-01-01 00:00:00]:
+              - icon [date: 2025-09-01 00:00:00]
+        - icon [date: 2026-01-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2026-01-01 00:00:00]
-              - icon_restart [2025-11-01 00:00:00]
+              - icon_input [date: 2026-01-01 00:00:00]
+              - icon_restart [date: 2025-11-01 00:00:00]
             output:
-              - stream_1 [2026-01-01 00:00:00]
-              - stream_2 [2026-01-01 00:00:00]
-              - icon_restart [2026-01-01 00:00:00]
-        - postproc_1 [2026-01-01 00:00:00]:
+              - stream_1 [date: 2026-01-01 00:00:00]
+              - stream_2 [date: 2026-01-01 00:00:00]
+              - icon_restart [date: 2026-01-01 00:00:00]
+        - postproc_1 [date: 2026-01-01 00:00:00]:
             input:
-              - stream_1 [2026-01-01 00:00:00]
+              - stream_1 [date: 2026-01-01 00:00:00]
             output:
-              - postout_1 [2026-01-01 00:00:00]
-        - store_and_clean_1 [2026-01-01 00:00:00]:
+              - postout_1 [date: 2026-01-01 00:00:00]
+        - store_and_clean_1 [date: 2026-01-01 00:00:00]:
             input:
-              - postout_1 [2026-01-01 00:00:00]
-              - stream_1 [2026-01-01 00:00:00]
-              - icon_input [2026-01-01 00:00:00]
+              - postout_1 [date: 2026-01-01 00:00:00]
+              - stream_1 [date: 2026-01-01 00:00:00]
+              - icon_input [date: 2026-01-01 00:00:00]
             output:
-              - stored_data_1 [2026-01-01 00:00:00]
-  - icon_bimonthly [2026-03-01 00:00:00]:
+              - stored_data_1 [date: 2026-01-01 00:00:00]
+  - icon_bimonthly [date: 2026-03-01 00:00:00]:
       tasks:
-        - preproc [2026-03-01 00:00:00]:
+        - preproc [date: 2026-03-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2026-03-01 00:00:00]
+              - icon_input [date: 2026-03-01 00:00:00]
             wait on:
-              - icon [2025-11-01 00:00:00]
-        - icon [2026-03-01 00:00:00]:
+              - icon [date: 2025-11-01 00:00:00]
+        - icon [date: 2026-03-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2026-03-01 00:00:00]
-              - icon_restart [2026-01-01 00:00:00]
+              - icon_input [date: 2026-03-01 00:00:00]
+              - icon_restart [date: 2026-01-01 00:00:00]
             output:
-              - stream_1 [2026-03-01 00:00:00]
-              - stream_2 [2026-03-01 00:00:00]
-              - icon_restart [2026-03-01 00:00:00]
-        - postproc_1 [2026-03-01 00:00:00]:
+              - stream_1 [date: 2026-03-01 00:00:00]
+              - stream_2 [date: 2026-03-01 00:00:00]
+              - icon_restart [date: 2026-03-01 00:00:00]
+        - postproc_1 [date: 2026-03-01 00:00:00]:
             input:
-              - stream_1 [2026-03-01 00:00:00]
+              - stream_1 [date: 2026-03-01 00:00:00]
             output:
-              - postout_1 [2026-03-01 00:00:00]
-        - store_and_clean_1 [2026-03-01 00:00:00]:
+              - postout_1 [date: 2026-03-01 00:00:00]
+        - store_and_clean_1 [date: 2026-03-01 00:00:00]:
             input:
-              - postout_1 [2026-03-01 00:00:00]
-              - stream_1 [2026-03-01 00:00:00]
-              - icon_input [2026-03-01 00:00:00]
+              - postout_1 [date: 2026-03-01 00:00:00]
+              - stream_1 [date: 2026-03-01 00:00:00]
+              - icon_input [date: 2026-03-01 00:00:00]
             output:
-              - stored_data_1 [2026-03-01 00:00:00]
-  - icon_bimonthly [2026-05-01 00:00:00]:
+              - stored_data_1 [date: 2026-03-01 00:00:00]
+  - icon_bimonthly [date: 2026-05-01 00:00:00]:
       tasks:
-        - preproc [2026-05-01 00:00:00]:
+        - preproc [date: 2026-05-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2026-05-01 00:00:00]
+              - icon_input [date: 2026-05-01 00:00:00]
             wait on:
-              - icon [2026-01-01 00:00:00]
-        - icon [2026-05-01 00:00:00]:
+              - icon [date: 2026-01-01 00:00:00]
+        - icon [date: 2026-05-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2026-05-01 00:00:00]
-              - icon_restart [2026-03-01 00:00:00]
+              - icon_input [date: 2026-05-01 00:00:00]
+              - icon_restart [date: 2026-03-01 00:00:00]
             output:
-              - stream_1 [2026-05-01 00:00:00]
-              - stream_2 [2026-05-01 00:00:00]
-              - icon_restart [2026-05-01 00:00:00]
-        - postproc_1 [2026-05-01 00:00:00]:
+              - stream_1 [date: 2026-05-01 00:00:00]
+              - stream_2 [date: 2026-05-01 00:00:00]
+              - icon_restart [date: 2026-05-01 00:00:00]
+        - postproc_1 [date: 2026-05-01 00:00:00]:
             input:
-              - stream_1 [2026-05-01 00:00:00]
+              - stream_1 [date: 2026-05-01 00:00:00]
             output:
-              - postout_1 [2026-05-01 00:00:00]
-        - store_and_clean_1 [2026-05-01 00:00:00]:
+              - postout_1 [date: 2026-05-01 00:00:00]
+        - store_and_clean_1 [date: 2026-05-01 00:00:00]:
             input:
-              - postout_1 [2026-05-01 00:00:00]
-              - stream_1 [2026-05-01 00:00:00]
-              - icon_input [2026-05-01 00:00:00]
+              - postout_1 [date: 2026-05-01 00:00:00]
+              - stream_1 [date: 2026-05-01 00:00:00]
+              - icon_input [date: 2026-05-01 00:00:00]
             output:
-              - stored_data_1 [2026-05-01 00:00:00]
-  - icon_bimonthly [2026-07-01 00:00:00]:
+              - stored_data_1 [date: 2026-05-01 00:00:00]
+  - icon_bimonthly [date: 2026-07-01 00:00:00]:
       tasks:
-        - preproc [2026-07-01 00:00:00]:
+        - preproc [date: 2026-07-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2026-07-01 00:00:00]
+              - icon_input [date: 2026-07-01 00:00:00]
             wait on:
-              - icon [2026-03-01 00:00:00]
-        - icon [2026-07-01 00:00:00]:
+              - icon [date: 2026-03-01 00:00:00]
+        - icon [date: 2026-07-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2026-07-01 00:00:00]
-              - icon_restart [2026-05-01 00:00:00]
+              - icon_input [date: 2026-07-01 00:00:00]
+              - icon_restart [date: 2026-05-01 00:00:00]
             output:
-              - stream_1 [2026-07-01 00:00:00]
-              - stream_2 [2026-07-01 00:00:00]
-              - icon_restart [2026-07-01 00:00:00]
-        - postproc_1 [2026-07-01 00:00:00]:
+              - stream_1 [date: 2026-07-01 00:00:00]
+              - stream_2 [date: 2026-07-01 00:00:00]
+              - icon_restart [date: 2026-07-01 00:00:00]
+        - postproc_1 [date: 2026-07-01 00:00:00]:
             input:
-              - stream_1 [2026-07-01 00:00:00]
+              - stream_1 [date: 2026-07-01 00:00:00]
             output:
-              - postout_1 [2026-07-01 00:00:00]
-        - store_and_clean_1 [2026-07-01 00:00:00]:
+              - postout_1 [date: 2026-07-01 00:00:00]
+        - store_and_clean_1 [date: 2026-07-01 00:00:00]:
             input:
-              - postout_1 [2026-07-01 00:00:00]
-              - stream_1 [2026-07-01 00:00:00]
-              - icon_input [2026-07-01 00:00:00]
+              - postout_1 [date: 2026-07-01 00:00:00]
+              - stream_1 [date: 2026-07-01 00:00:00]
+              - icon_input [date: 2026-07-01 00:00:00]
             output:
-              - stored_data_1 [2026-07-01 00:00:00]
-  - icon_bimonthly [2026-09-01 00:00:00]:
+              - stored_data_1 [date: 2026-07-01 00:00:00]
+  - icon_bimonthly [date: 2026-09-01 00:00:00]:
       tasks:
-        - preproc [2026-09-01 00:00:00]:
+        - preproc [date: 2026-09-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2026-09-01 00:00:00]
+              - icon_input [date: 2026-09-01 00:00:00]
             wait on:
-              - icon [2026-05-01 00:00:00]
-        - icon [2026-09-01 00:00:00]:
+              - icon [date: 2026-05-01 00:00:00]
+        - icon [date: 2026-09-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2026-09-01 00:00:00]
-              - icon_restart [2026-07-01 00:00:00]
+              - icon_input [date: 2026-09-01 00:00:00]
+              - icon_restart [date: 2026-07-01 00:00:00]
             output:
-              - stream_1 [2026-09-01 00:00:00]
-              - stream_2 [2026-09-01 00:00:00]
-              - icon_restart [2026-09-01 00:00:00]
-        - postproc_1 [2026-09-01 00:00:00]:
+              - stream_1 [date: 2026-09-01 00:00:00]
+              - stream_2 [date: 2026-09-01 00:00:00]
+              - icon_restart [date: 2026-09-01 00:00:00]
+        - postproc_1 [date: 2026-09-01 00:00:00]:
             input:
-              - stream_1 [2026-09-01 00:00:00]
+              - stream_1 [date: 2026-09-01 00:00:00]
             output:
-              - postout_1 [2026-09-01 00:00:00]
-        - store_and_clean_1 [2026-09-01 00:00:00]:
+              - postout_1 [date: 2026-09-01 00:00:00]
+        - store_and_clean_1 [date: 2026-09-01 00:00:00]:
             input:
-              - postout_1 [2026-09-01 00:00:00]
-              - stream_1 [2026-09-01 00:00:00]
-              - icon_input [2026-09-01 00:00:00]
+              - postout_1 [date: 2026-09-01 00:00:00]
+              - stream_1 [date: 2026-09-01 00:00:00]
+              - icon_input [date: 2026-09-01 00:00:00]
             output:
-              - stored_data_1 [2026-09-01 00:00:00]
-  - icon_bimonthly [2026-11-01 00:00:00]:
+              - stored_data_1 [date: 2026-09-01 00:00:00]
+  - icon_bimonthly [date: 2026-11-01 00:00:00]:
       tasks:
-        - preproc [2026-11-01 00:00:00]:
+        - preproc [date: 2026-11-01 00:00:00]:
             input:
               - grid_file
               - extpar_file
               - ERA5
             output:
-              - icon_input [2026-11-01 00:00:00]
+              - icon_input [date: 2026-11-01 00:00:00]
             wait on:
-              - icon [2026-07-01 00:00:00]
-        - icon [2026-11-01 00:00:00]:
+              - icon [date: 2026-07-01 00:00:00]
+        - icon [date: 2026-11-01 00:00:00]:
             input:
               - grid_file
-              - icon_input [2026-11-01 00:00:00]
-              - icon_restart [2026-09-01 00:00:00]
+              - icon_input [date: 2026-11-01 00:00:00]
+              - icon_restart [date: 2026-09-01 00:00:00]
             output:
-              - stream_1 [2026-11-01 00:00:00]
-              - stream_2 [2026-11-01 00:00:00]
-              - icon_restart [2026-11-01 00:00:00]
-        - postproc_1 [2026-11-01 00:00:00]:
+              - stream_1 [date: 2026-11-01 00:00:00]
+              - stream_2 [date: 2026-11-01 00:00:00]
+              - icon_restart [date: 2026-11-01 00:00:00]
+        - postproc_1 [date: 2026-11-01 00:00:00]:
             input:
-              - stream_1 [2026-11-01 00:00:00]
+              - stream_1 [date: 2026-11-01 00:00:00]
             output:
-              - postout_1 [2026-11-01 00:00:00]
-        - store_and_clean_1 [2026-11-01 00:00:00]:
+              - postout_1 [date: 2026-11-01 00:00:00]
+        - store_and_clean_1 [date: 2026-11-01 00:00:00]:
             input:
-              - postout_1 [2026-11-01 00:00:00]
-              - stream_1 [2026-11-01 00:00:00]
-              - icon_input [2026-11-01 00:00:00]
+              - postout_1 [date: 2026-11-01 00:00:00]
+              - stream_1 [date: 2026-11-01 00:00:00]
+              - icon_input [date: 2026-11-01 00:00:00]
             output:
-              - stored_data_1 [2026-11-01 00:00:00]
-  - yearly [2025-01-01 00:00:00]:
+              - stored_data_1 [date: 2026-11-01 00:00:00]
+  - yearly [date: 2025-01-01 00:00:00]:
       tasks:
-        - postproc_2 [2025-01-01 00:00:00]:
+        - postproc_2 [date: 2025-01-01 00:00:00]:
             input:
-              - stream_2 [2025-01-01 00:00:00]
-              - stream_2 [2025-03-01 00:00:00]
-              - stream_2 [2025-05-01 00:00:00]
-              - stream_2 [2025-07-01 00:00:00]
-              - stream_2 [2025-09-01 00:00:00]
-              - stream_2 [2025-11-01 00:00:00]
+              - stream_2 [date: 2025-01-01 00:00:00]
+              - stream_2 [date: 2025-03-01 00:00:00]
+              - stream_2 [date: 2025-05-01 00:00:00]
+              - stream_2 [date: 2025-07-01 00:00:00]
+              - stream_2 [date: 2025-09-01 00:00:00]
+              - stream_2 [date: 2025-11-01 00:00:00]
             output:
-              - postout_2 [2025-01-01 00:00:00]
-        - store_and_clean_2 [2025-01-01 00:00:00]:
+              - postout_2 [date: 2025-01-01 00:00:00]
+        - store_and_clean_2 [date: 2025-01-01 00:00:00]:
             input:
-              - postout_2 [2025-01-01 00:00:00]
-              - stream_2 [2025-01-01 00:00:00]
-              - stream_2 [2025-03-01 00:00:00]
-              - stream_2 [2025-05-01 00:00:00]
-              - stream_2 [2025-07-01 00:00:00]
-              - stream_2 [2025-09-01 00:00:00]
-              - stream_2 [2025-11-01 00:00:00]
+              - postout_2 [date: 2025-01-01 00:00:00]
+              - stream_2 [date: 2025-01-01 00:00:00]
+              - stream_2 [date: 2025-03-01 00:00:00]
+              - stream_2 [date: 2025-05-01 00:00:00]
+              - stream_2 [date: 2025-07-01 00:00:00]
+              - stream_2 [date: 2025-09-01 00:00:00]
+              - stream_2 [date: 2025-11-01 00:00:00]
             output:
-              - stored_data_2 [2025-01-01 00:00:00]
-  - yearly [2026-01-01 00:00:00]:
+              - stored_data_2 [date: 2025-01-01 00:00:00]
+  - yearly [date: 2026-01-01 00:00:00]:
       tasks:
-        - postproc_2 [2026-01-01 00:00:00]:
+        - postproc_2 [date: 2026-01-01 00:00:00]:
             input:
-              - stream_2 [2026-01-01 00:00:00]
-              - stream_2 [2026-03-01 00:00:00]
-              - stream_2 [2026-05-01 00:00:00]
-              - stream_2 [2026-07-01 00:00:00]
-              - stream_2 [2026-09-01 00:00:00]
-              - stream_2 [2026-11-01 00:00:00]
+              - stream_2 [date: 2026-01-01 00:00:00]
+              - stream_2 [date: 2026-03-01 00:00:00]
+              - stream_2 [date: 2026-05-01 00:00:00]
+              - stream_2 [date: 2026-07-01 00:00:00]
+              - stream_2 [date: 2026-09-01 00:00:00]
+              - stream_2 [date: 2026-11-01 00:00:00]
             output:
-              - postout_2 [2026-01-01 00:00:00]
-        - store_and_clean_2 [2026-01-01 00:00:00]:
+              - postout_2 [date: 2026-01-01 00:00:00]
+        - store_and_clean_2 [date: 2026-01-01 00:00:00]:
             input:
-              - postout_2 [2026-01-01 00:00:00]
-              - stream_2 [2026-01-01 00:00:00]
-              - stream_2 [2026-03-01 00:00:00]
-              - stream_2 [2026-05-01 00:00:00]
-              - stream_2 [2026-07-01 00:00:00]
-              - stream_2 [2026-09-01 00:00:00]
-              - stream_2 [2026-11-01 00:00:00]
+              - postout_2 [date: 2026-01-01 00:00:00]
+              - stream_2 [date: 2026-01-01 00:00:00]
+              - stream_2 [date: 2026-03-01 00:00:00]
+              - stream_2 [date: 2026-05-01 00:00:00]
+              - stream_2 [date: 2026-07-01 00:00:00]
+              - stream_2 [date: 2026-09-01 00:00:00]
+              - stream_2 [date: 2026-11-01 00:00:00]
             output:
-              - stored_data_2 [2026-01-01 00:00:00]
+              - stored_data_2 [date: 2026-01-01 00:00:00]

--- a/tests/files/data/test_config_parameters.txt
+++ b/tests/files/data/test_config_parameters.txt
@@ -1,0 +1,793 @@
+cycles:
+  - bimonthly_tasks [date: 2026-01-01 00:00:00]:
+      tasks:
+        - icon [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - initial conditions
+              - forcing
+            output:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - initial conditions
+              - forcing
+            output:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - initial conditions
+              - forcing
+            output:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - initial conditions
+              - forcing
+            output:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - initial conditions
+              - forcing
+            output:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - initial conditions
+              - forcing
+            output:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2026-01-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2026-01-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2026-01-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2026-01-01 00:00:00]
+  - bimonthly_tasks [date: 2026-03-01 00:00:00]:
+      tasks:
+        - icon [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2026-03-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2026-03-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2026-03-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2026-03-01 00:00:00]
+  - bimonthly_tasks [date: 2026-05-01 00:00:00]:
+      tasks:
+        - icon [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2026-05-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2026-05-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2026-05-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2026-05-01 00:00:00]
+  - bimonthly_tasks [date: 2026-07-01 00:00:00]:
+      tasks:
+        - icon [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2026-07-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2026-07-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2026-07-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2026-07-01 00:00:00]
+  - bimonthly_tasks [date: 2026-09-01 00:00:00]:
+      tasks:
+        - icon [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2026-09-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2026-09-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2026-09-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2026-09-01 00:00:00]
+  - bimonthly_tasks [date: 2026-11-01 00:00:00]:
+      tasks:
+        - icon [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2026-11-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2026-11-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2026-11-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2026-11-01 00:00:00]
+  - bimonthly_tasks [date: 2027-01-01 00:00:00]:
+      tasks:
+        - icon [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2027-01-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2027-01-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2027-01-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2027-01-01 00:00:00]
+  - bimonthly_tasks [date: 2027-03-01 00:00:00]:
+      tasks:
+        - icon [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2027-03-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2027-03-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2027-03-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2027-03-01 00:00:00]
+  - bimonthly_tasks [date: 2027-05-01 00:00:00]:
+      tasks:
+        - icon [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2027-05-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2027-05-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2027-05-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2027-05-01 00:00:00]
+  - bimonthly_tasks [date: 2027-07-01 00:00:00]:
+      tasks:
+        - icon [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2027-07-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2027-07-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2027-07-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2027-07-01 00:00:00]
+  - bimonthly_tasks [date: 2027-09-01 00:00:00]:
+      tasks:
+        - icon [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2027-09-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2027-09-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2027-09-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2027-09-01 00:00:00]
+  - bimonthly_tasks [date: 2027-11-01 00:00:00]:
+      tasks:
+        - icon [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_restart [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]
+        - icon [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_restart [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]
+        - icon [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_restart [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]
+        - icon [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_restart [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]
+        - icon [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]:
+            input:
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
+              - forcing
+            output:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]
+              - icon_restart [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]
+        - icon [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]:
+            input:
+              - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
+              - forcing
+            output:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]
+              - icon_restart [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]
+        - statistics_foo [date: 2027-11-01 00:00:00, bar: 3.0]:
+            input:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]
+              - icon_output [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]
+              - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]
+            output:
+              - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.0]
+        - statistics_foo [date: 2027-11-01 00:00:00, bar: 3.5]:
+            input:
+              - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]
+              - icon_output [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]
+              - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]
+            output:
+              - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.5]
+        - statistics_foo_bar [date: 2027-11-01 00:00:00]:
+            input:
+              - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.5]
+              - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.0]
+            output:
+              - analysis_foo_bar [date: 2027-11-01 00:00:00]
+  - yearly [date: 2026-01-01 00:00:00]:
+      tasks:
+        - merge [date: 2026-01-01 00:00:00]:
+            input:
+              - analysis_foo_bar [date: 2026-01-01 00:00:00]
+              - analysis_foo_bar [date: 2026-03-01 00:00:00]
+              - analysis_foo_bar [date: 2026-05-01 00:00:00]
+              - analysis_foo_bar [date: 2026-07-01 00:00:00]
+              - analysis_foo_bar [date: 2026-09-01 00:00:00]
+              - analysis_foo_bar [date: 2026-11-01 00:00:00]
+            output:
+              - yearly_analysis [date: 2026-01-01 00:00:00]
+  - yearly [date: 2027-01-01 00:00:00]:
+      tasks:
+        - merge [date: 2027-01-01 00:00:00]:
+            input:
+              - analysis_foo_bar [date: 2027-01-01 00:00:00]
+              - analysis_foo_bar [date: 2027-03-01 00:00:00]
+              - analysis_foo_bar [date: 2027-05-01 00:00:00]
+              - analysis_foo_bar [date: 2027-07-01 00:00:00]
+              - analysis_foo_bar [date: 2027-09-01 00:00:00]
+              - analysis_foo_bar [date: 2027-11-01 00:00:00]
+            output:
+              - yearly_analysis [date: 2027-01-01 00:00:00]

--- a/tests/files/data/test_config_small.txt
+++ b/tests/files/data/test_config_small.txt
@@ -1,28 +1,28 @@
 cycles:
-  - bimonthly_tasks [2026-01-01 00:00:00]:
+  - bimonthly_tasks [date: 2026-01-01 00:00:00]:
       tasks:
-        - icon [2026-01-01 00:00:00]:
+        - icon [date: 2026-01-01 00:00:00]:
             output:
-              - icon_output [2026-01-01 00:00:00]
-              - icon_restart [2026-01-01 00:00:00]
-  - bimonthly_tasks [2026-03-01 00:00:00]:
+              - icon_output [date: 2026-01-01 00:00:00]
+              - icon_restart [date: 2026-01-01 00:00:00]
+  - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
-        - icon [2026-03-01 00:00:00]:
+        - icon [date: 2026-03-01 00:00:00]:
             input:
-              - icon_restart [2026-01-01 00:00:00]
+              - icon_restart [date: 2026-01-01 00:00:00]
             output:
-              - icon_output [2026-03-01 00:00:00]
-              - icon_restart [2026-03-01 00:00:00]
-  - bimonthly_tasks [2026-05-01 00:00:00]:
+              - icon_output [date: 2026-03-01 00:00:00]
+              - icon_restart [date: 2026-03-01 00:00:00]
+  - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
-        - icon [2026-05-01 00:00:00]:
+        - icon [date: 2026-05-01 00:00:00]:
             input:
-              - icon_restart [2026-03-01 00:00:00]
+              - icon_restart [date: 2026-03-01 00:00:00]
             output:
-              - icon_output [2026-05-01 00:00:00]
-              - icon_restart [2026-05-01 00:00:00]
+              - icon_output [date: 2026-05-01 00:00:00]
+              - icon_restart [date: 2026-05-01 00:00:00]
   - lastly:
       tasks:
         - cleanup:
             wait on:
-              - icon [2026-05-01 00:00:00]
+              - icon [date: 2026-05-01 00:00:00]

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -39,7 +39,7 @@ def test_parse_config_file(config_case, pprinter):
 
 
 @pytest.mark.skip(reason="don't run it each time, uncomment to regenerate serilaized data")
-def test_serialize_workflow(config_case):
+def test_serialize_workflow(config_case, pprinter):
     config_path, reference_path = config_case
     reference_path.write_text(pprinter.format(Workflow.from_yaml(config_path)))
 

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -15,6 +15,7 @@ def pprinter():
 config_test_files = [
     "tests/files/configs/test_config_small.yml",
     "tests/files/configs/test_config_large.yml",
+    "tests/files/configs/test_config_parameters.yml",
 ]
 
 


### PR DESCRIPTION
## Part 1
- [x] Add the `when` key to address #40.
- [x]  As a result, keeping track of dates in the `TimeSeries` class is not necessary anymore. Still a more generic `Array` container is required for parametrized tasks and data, so it is implemented instead of just ditching `TimeSeries` and temporarily use regular dictionaries. `"date"` is now just one of the possible coordinates receiving a special treatment when resolving dependencies.

## Part 2
- [x] Introduce parametrized tasks and data in parsing to address #44
- [x] turn `core.Task.from_config` and `core.Data.from_config` into generators