### PR TITLE
Fixes pygraphviz failure when building wheels

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -10,6 +11,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ['3.12']
+
     steps:
 
     - uses: actions/checkout@v4
@@ -18,13 +24,21 @@ jobs:
       run: |
         git config user.name github-actions[bot]
         git config user.email github-actions[bot]@users.noreply.github.com
-
-    - uses: actions/setup-python@v5
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: ${{ matrix.python-version }}
 
-    - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+    - name: Install hatch
+      run: |
+        pip install --upgrade pip
+        pip install hatch
 
+    - name: Install Graphviz
+      run: sudo apt-get install graphviz graphviz-dev
+
+    # caches the build docs
+    # see https://squidfunk.github.io/mkdocs-material/plugins/requirements/caching/
     - uses: actions/cache@v4
       with:
         key: mkdocs-material-${{ env.cache_id }}
@@ -34,5 +48,4 @@ jobs:
 
     - name: "Build and deploy docs to gh-pages"
       run: |
-        pip install hatch
-        hatch run docs:deploy --force
+        hatch run docs:deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,5 @@ serve = [
 ]
 
 deploy = [
-  "mkdocs gh-deploy -f docs/mkdocs.yml"
+  "mkdocs gh-deploy --no-history -f docs/mkdocs.yml"
 ]


### PR DESCRIPTION
One needs to install graphviz over the system package manager before installing pygraphviz to prevent an automatic build that fails. This can is achieved widh `sudo apt-get install graphviz graphviz-dev`.

We also add the `workflow_dispatch` event so we can run the workflow manually.