### PR TITLE
Adds parsing of `ShellTask` and `IconTask` from the config file

### DIFF
--- a/src/sirocco/core/_tasks/icon_task.py
+++ b/src/sirocco/core/_tasks/icon_task.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from sirocco.core.graph_items import Task
+from sirocco.parsing import ConfigIconTask
 
 
 @dataclass
 class IconTask(Task):
-    plugin: ClassVar[str] = "icon"
+    plugin: ClassVar[Literal[ConfigIconTask.plugin]] = ConfigIconTask.plugin
 
     namelists: dict = field(default_factory=dict)

--- a/src/sirocco/core/_tasks/shell_task.py
+++ b/src/sirocco/core/_tasks/shell_task.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from sirocco.core.graph_items import Task
+from sirocco.parsing import ConfigShellTask
 
 
 @dataclass
 class ShellTask(Task):
-    plugin: ClassVar[str] = "shell"
+    # plugin: ClassVar[str] = "shell"
+    plugin: ClassVar[Literal[ConfigShellTask.plugin]] = ConfigShellTask.plugin
 
     command: str | None = None
     command_option: str | None = None

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from itertools import chain, product
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self
+
+from sirocco.parsing import ConfigBaseTask
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -47,7 +49,7 @@ class TaskPlugin(type):
 class Task(GraphItem, metaclass=TaskPlugin):
     """Internal representation of a task node"""
 
-    plugin: ClassVar[str] = "_BASE_TASK"
+    plugin: ClassVar[Literal[ConfigBaseTask.plugin]] = ConfigBaseTask.plugin
     color: ClassVar[str] = field(default="light_red", repr=False)
 
     inputs: list[Data] = field(default_factory=list)
@@ -74,8 +76,7 @@ class Task(GraphItem, metaclass=TaskPlugin):
         # use the fact that pydantic models can be turned into dicts easily
         cls_config = dict(config)
         del cls_config["parameters"]
-        del cls_config["plugin"]
-        if (plugin_cls := TaskPlugin.classes.get(config.plugin, None)) is None:
+        if (plugin_cls := TaskPlugin.classes.get(type(config).plugin, None)) is None:
             msg = f"Plugin {config.plugin!r} is not supported."
             raise ValueError(msg)
 

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -20,31 +20,35 @@ class GraphItem:
     coordinates: dict = field(default_factory=dict)
 
 
-class Plugin(type):
+class TaskPlugin(type):
     """Metaclass for plugin tasks inheriting from Task
 
     Used to register all plugin task classes"""
 
-    classes: dict[str, type] | None = None
+    classes: ClassVar[dict[str, type[Task]]] = {}
 
-    def __new__(cls, name, bases, dct):
-        if cls.classes is None:
-            cls.classes = {}
-        plugin = dct["plugin"]
+    def __new__(cls, name: str, bases: tuple, attr: dict):
+        """Invoked on class definition when used as metaclass.
+
+        name: The name of the class
+        bases: The base classes from the class
+        attr: The attributes of the class
+        """
+        plugin = attr["plugin"]
         if plugin in cls.classes:
             msg = f"Task for plugin {plugin} already set"
             raise ValueError(msg)
-        return_cls = super().__new__(cls, name, bases, dct)
+        return_cls = super().__new__(cls, name, bases, attr)
         cls.classes[plugin] = return_cls
         return return_cls
 
 
 @dataclass
-class Task(GraphItem, metaclass=Plugin):
+class Task(GraphItem, metaclass=TaskPlugin):
     """Internal representation of a task node"""
 
     plugin: ClassVar[str] = "_BASE_TASK"
-    color: ClassVar[str] = "light_red"
+    color: ClassVar[str] = field(default="light_red", repr=False)
 
     inputs: list[Data] = field(default_factory=list)
     outputs: list[Data] = field(default_factory=list)
@@ -71,7 +75,11 @@ class Task(GraphItem, metaclass=Plugin):
         cls_config = dict(config)
         del cls_config["parameters"]
         del cls_config["plugin"]
-        new = Plugin.classes[config.plugin](
+        if (plugin_cls := TaskPlugin.classes.get(config.plugin, None)) is None:
+            msg = f"Plugin {config.plugin!r} is not supported."
+            raise ValueError(msg)
+
+        new = plugin_cls(
             coordinates=coordinates,
             inputs=inputs,
             outputs=outputs,

--- a/src/sirocco/parsing/__init__.py
+++ b/src/sirocco/parsing/__init__.py
@@ -1,5 +1,13 @@
-from ._yaml_data_models import load_workflow_config
+from ._yaml_data_models import (
+    ConfigBaseTask,
+    ConfigIconTask,
+    ConfigShellTask,
+    load_workflow_config,
+)
 
 __all__ = [
     "load_workflow_config",
+    "ConfigBaseTask",
+    "ConfigShellTask",
+    "ConfigIconTask",
 ]

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 
 from isoduration import parse_duration
 from isoduration.types import Duration  # pydantic needs type # noqa: TCH002
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator, model_validator
 
-from ._utils import TimeUtils
+from sirocco.core._tasks.icon_task import IconTask
+from sirocco.core._tasks.shell_task import ShellTask
+from sirocco.core.graph_items import Task
+from sirocco.parsing._utils import TimeUtils
 
 
 class _NamedBaseModel(BaseModel):
@@ -29,9 +32,22 @@ class _NamedBaseModel(BaseModel):
     name: str
 
     def __init__(self, /, **data):
+        super().__init__(**self.merge_name_and_specs(data))
+
+    @staticmethod
+    def merge_name_and_specs(data: dict) -> dict:
+        """
+        Converts dict of form
+
+        `{my_name: {'spec_0': ..., ..., 'spec_n': ...}`
+
+        to
+
+        `{'name': my_name, 'spec_0': ..., ..., 'spec_n': ...}`
+
+        by copy.
+        """
         name_and_spec = {}
-        # - my_name:
-        #     ...
         if len(data) != 1:
             msg = f"Expected dict with one element of the form {{'name': specification}} but got {data}."
             raise ValueError(msg)
@@ -39,8 +55,7 @@ class _NamedBaseModel(BaseModel):
         # if no specification specified e.g. "- my_name:"
         if (spec := next(iter(data.values()))) is not None:
             name_and_spec.update(spec)
-
-        super().__init__(**name_and_spec)
+        return name_and_spec
 
 
 class _WhenBaseModel(BaseModel):
@@ -229,16 +244,17 @@ class ConfigCycle(_NamedBaseModel):
         return self
 
 
-class ConfigTask(_NamedBaseModel):
+class ConfigBaseTask(_NamedBaseModel):
     """
-    To create an instance of a task defined in a workflow file
+    config for genric task, no plugin specifics
     """
 
-    # config for genric task, no plugin specifics
-    parameters: list[str] = []
+    # this class could be used for constructing a root task we therefore need a
+    # default value for the plugin as it is not required
+    plugin: Literal[Task.plugin] | None = None
+    parameters: list[str] = Field(default_factory=list)
     host: str | None = None
     account: str | None = None
-    plugin: str | None = None
     uenv: dict | None = None
     nodes: int | None = None
     walltime: str | None = None
@@ -256,7 +272,17 @@ class ConfigTask(_NamedBaseModel):
         return None if value is None else time.strptime(value, "%H:%M:%S")
 
 
-# TODO(maybe): ConfigTaskIcon(ConfigTask) and ConfigTaskShell(ConfigTask)
+class ConfigShellTask(ConfigBaseTask):
+    plugin: Literal[ShellTask.plugin]
+    command: str
+    command_option: str = ""
+    input_arg_options: dict[str, str] = Field(default_factory=dict)
+    src: str | None = None
+
+
+class ConfigIconTask(ConfigBaseTask):
+    plugin: Literal[IconTask.plugin]
+    namelists: dict[str, Any]
 
 
 class DataBaseModel(_NamedBaseModel):
@@ -296,6 +322,25 @@ class ConfigData(BaseModel):
 
     available: list[ConfigAvailableData] = []
     generated: list[ConfigGeneratedData] = []
+
+
+def get_plugin_from_named_base_model(data: dict) -> str:
+    name_and_specs = _NamedBaseModel.merge_name_and_specs(data)
+    if name_and_specs.get("name", None) == "ROOT":
+        return Task.plugin
+    plugin = name_and_specs.get("plugin", None)
+    if plugin is None:
+        msg = "Could not find plugin name in {data}"
+        raise ValueError(msg)
+    return plugin
+
+
+ConfigTask = Annotated[
+    Annotated[ConfigBaseTask, Tag(Task.plugin)]
+    | Annotated[ConfigIconTask, Tag(IconTask.plugin)]
+    | Annotated[ConfigShellTask, Tag(ShellTask.plugin)],
+    Discriminator(get_plugin_from_named_base_model),
+]
 
 
 class ConfigWorkflow(BaseModel):

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, ClassVar, Literal
 
 from isoduration import parse_duration
 from isoduration.types import Duration  # pydantic needs type # noqa: TCH002
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator, model_validator
 
-from sirocco.core._tasks.icon_task import IconTask
-from sirocco.core._tasks.shell_task import ShellTask
-from sirocco.core.graph_items import Task
+# from sirocco.core._tasks.icon_task import IconTask
+# from sirocco.core._tasks.shell_task import ShellTask
+# from sirocco.core.graph_items import Task
 from sirocco.parsing._utils import TimeUtils
 
 
@@ -251,7 +251,8 @@ class ConfigBaseTask(_NamedBaseModel):
 
     # this class could be used for constructing a root task we therefore need a
     # default value for the plugin as it is not required
-    plugin: Literal[Task.plugin] | None = None
+    # plugin: Literal[Task.plugin] | None = None
+    plugin: ClassVar[Literal["_BASE_TASK_"]] = "_BASE_TASK_"
     parameters: list[str] = Field(default_factory=list)
     host: str | None = None
     account: str | None = None
@@ -273,7 +274,8 @@ class ConfigBaseTask(_NamedBaseModel):
 
 
 class ConfigShellTask(ConfigBaseTask):
-    plugin: Literal[ShellTask.plugin]
+    # plugin: Literal[ShellTask.plugin]
+    plugin: ClassVar[Literal["shell"]] = "shell"
     command: str
     command_option: str = ""
     input_arg_options: dict[str, str] = Field(default_factory=dict)
@@ -281,7 +283,8 @@ class ConfigShellTask(ConfigBaseTask):
 
 
 class ConfigIconTask(ConfigBaseTask):
-    plugin: Literal[IconTask.plugin]
+    # plugin: Literal[IconTask.plugin]
+    plugin: ClassVar[Literal["icon"]] = "icon"
     namelists: dict[str, Any]
 
 
@@ -327,7 +330,7 @@ class ConfigData(BaseModel):
 def get_plugin_from_named_base_model(data: dict) -> str:
     name_and_specs = _NamedBaseModel.merge_name_and_specs(data)
     if name_and_specs.get("name", None) == "ROOT":
-        return Task.plugin
+        return ConfigBaseTask.plugin
     plugin = name_and_specs.get("plugin", None)
     if plugin is None:
         msg = "Could not find plugin name in {data}"
@@ -336,9 +339,9 @@ def get_plugin_from_named_base_model(data: dict) -> str:
 
 
 ConfigTask = Annotated[
-    Annotated[ConfigBaseTask, Tag(Task.plugin)]
-    | Annotated[ConfigIconTask, Tag(IconTask.plugin)]
-    | Annotated[ConfigShellTask, Tag(ShellTask.plugin)],
+    Annotated[ConfigBaseTask, Tag(ConfigBaseTask.plugin)]
+    | Annotated[ConfigIconTask, Tag(ConfigIconTask.plugin)]
+    | Annotated[ConfigShellTask, Tag(ConfigShellTask.plugin)],
     Discriminator(get_plugin_from_named_base_model),
 ]
 

--- a/tests/files/data/test_config_large.txt
+++ b/tests/files/data/test_config_large.txt
@@ -6,6 +6,15 @@ cycles:
               - obs_data
             output:
               - extpar_file
+            name: 'extpar'
+            coordinates: {}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/extpar'
+            command option: '--verbose'
+            input arg options: {'obs_data': '--input'}
   - icon_bimonthly [date: 2025-01-01 00:00:00]:
       tasks:
         - preproc [date: 2025-01-01 00:00:00]:
@@ -15,6 +24,15 @@ cycles:
               - ERA5
             output:
               - icon_input [date: 2025-01-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2025-01-01 00:00:00]:
             input:
               - grid_file
@@ -23,11 +41,27 @@ cycles:
               - stream_1 [date: 2025-01-01 00:00:00]
               - stream_2 [date: 2025-01-01 00:00:00]
               - icon_restart [date: 2025-01-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2025-01-01 00:00:00]:
             input:
               - stream_1 [date: 2025-01-01 00:00:00]
             output:
               - postout_1 [date: 2025-01-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2025-01-01 00:00:00]:
             input:
               - postout_1 [date: 2025-01-01 00:00:00]
@@ -35,6 +69,14 @@ cycles:
               - icon_input [date: 2025-01-01 00:00:00]
             output:
               - stored_data_1 [date: 2025-01-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2025-03-01 00:00:00]:
       tasks:
         - preproc [date: 2025-03-01 00:00:00]:
@@ -44,6 +86,15 @@ cycles:
               - ERA5
             output:
               - icon_input [date: 2025-03-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2025-03-01 00:00:00]:
             input:
               - grid_file
@@ -53,11 +104,27 @@ cycles:
               - stream_1 [date: 2025-03-01 00:00:00]
               - stream_2 [date: 2025-03-01 00:00:00]
               - icon_restart [date: 2025-03-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2025-03-01 00:00:00]:
             input:
               - stream_1 [date: 2025-03-01 00:00:00]
             output:
               - postout_1 [date: 2025-03-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2025-03-01 00:00:00]:
             input:
               - postout_1 [date: 2025-03-01 00:00:00]
@@ -65,6 +132,14 @@ cycles:
               - icon_input [date: 2025-03-01 00:00:00]
             output:
               - stored_data_1 [date: 2025-03-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2025-05-01 00:00:00]:
       tasks:
         - preproc [date: 2025-05-01 00:00:00]:
@@ -76,6 +151,15 @@ cycles:
               - icon_input [date: 2025-05-01 00:00:00]
             wait on:
               - icon [date: 2025-01-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2025-05-01 00:00:00]:
             input:
               - grid_file
@@ -85,11 +169,27 @@ cycles:
               - stream_1 [date: 2025-05-01 00:00:00]
               - stream_2 [date: 2025-05-01 00:00:00]
               - icon_restart [date: 2025-05-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2025-05-01 00:00:00]:
             input:
               - stream_1 [date: 2025-05-01 00:00:00]
             output:
               - postout_1 [date: 2025-05-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2025-05-01 00:00:00]:
             input:
               - postout_1 [date: 2025-05-01 00:00:00]
@@ -97,6 +197,14 @@ cycles:
               - icon_input [date: 2025-05-01 00:00:00]
             output:
               - stored_data_1 [date: 2025-05-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2025-07-01 00:00:00]:
       tasks:
         - preproc [date: 2025-07-01 00:00:00]:
@@ -108,6 +216,15 @@ cycles:
               - icon_input [date: 2025-07-01 00:00:00]
             wait on:
               - icon [date: 2025-03-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2025-07-01 00:00:00]:
             input:
               - grid_file
@@ -117,11 +234,27 @@ cycles:
               - stream_1 [date: 2025-07-01 00:00:00]
               - stream_2 [date: 2025-07-01 00:00:00]
               - icon_restart [date: 2025-07-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2025-07-01 00:00:00]:
             input:
               - stream_1 [date: 2025-07-01 00:00:00]
             output:
               - postout_1 [date: 2025-07-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2025-07-01 00:00:00]:
             input:
               - postout_1 [date: 2025-07-01 00:00:00]
@@ -129,6 +262,14 @@ cycles:
               - icon_input [date: 2025-07-01 00:00:00]
             output:
               - stored_data_1 [date: 2025-07-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2025-09-01 00:00:00]:
       tasks:
         - preproc [date: 2025-09-01 00:00:00]:
@@ -140,6 +281,15 @@ cycles:
               - icon_input [date: 2025-09-01 00:00:00]
             wait on:
               - icon [date: 2025-05-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2025-09-01 00:00:00]:
             input:
               - grid_file
@@ -149,11 +299,27 @@ cycles:
               - stream_1 [date: 2025-09-01 00:00:00]
               - stream_2 [date: 2025-09-01 00:00:00]
               - icon_restart [date: 2025-09-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2025-09-01 00:00:00]:
             input:
               - stream_1 [date: 2025-09-01 00:00:00]
             output:
               - postout_1 [date: 2025-09-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2025-09-01 00:00:00]:
             input:
               - postout_1 [date: 2025-09-01 00:00:00]
@@ -161,6 +327,14 @@ cycles:
               - icon_input [date: 2025-09-01 00:00:00]
             output:
               - stored_data_1 [date: 2025-09-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2025-11-01 00:00:00]:
       tasks:
         - preproc [date: 2025-11-01 00:00:00]:
@@ -172,6 +346,15 @@ cycles:
               - icon_input [date: 2025-11-01 00:00:00]
             wait on:
               - icon [date: 2025-07-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2025-11-01 00:00:00]:
             input:
               - grid_file
@@ -181,11 +364,27 @@ cycles:
               - stream_1 [date: 2025-11-01 00:00:00]
               - stream_2 [date: 2025-11-01 00:00:00]
               - icon_restart [date: 2025-11-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2025-11-01 00:00:00]:
             input:
               - stream_1 [date: 2025-11-01 00:00:00]
             output:
               - postout_1 [date: 2025-11-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2025-11-01 00:00:00]:
             input:
               - postout_1 [date: 2025-11-01 00:00:00]
@@ -193,6 +392,14 @@ cycles:
               - icon_input [date: 2025-11-01 00:00:00]
             output:
               - stored_data_1 [date: 2025-11-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2026-01-01 00:00:00]:
       tasks:
         - preproc [date: 2026-01-01 00:00:00]:
@@ -204,6 +411,15 @@ cycles:
               - icon_input [date: 2026-01-01 00:00:00]
             wait on:
               - icon [date: 2025-09-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2026-01-01 00:00:00]:
             input:
               - grid_file
@@ -213,11 +429,27 @@ cycles:
               - stream_1 [date: 2026-01-01 00:00:00]
               - stream_2 [date: 2026-01-01 00:00:00]
               - icon_restart [date: 2026-01-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2026-01-01 00:00:00]:
             input:
               - stream_1 [date: 2026-01-01 00:00:00]
             output:
               - postout_1 [date: 2026-01-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2026-01-01 00:00:00]:
             input:
               - postout_1 [date: 2026-01-01 00:00:00]
@@ -225,6 +457,14 @@ cycles:
               - icon_input [date: 2026-01-01 00:00:00]
             output:
               - stored_data_1 [date: 2026-01-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2026-03-01 00:00:00]:
       tasks:
         - preproc [date: 2026-03-01 00:00:00]:
@@ -236,6 +476,15 @@ cycles:
               - icon_input [date: 2026-03-01 00:00:00]
             wait on:
               - icon [date: 2025-11-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2026-03-01 00:00:00]:
             input:
               - grid_file
@@ -245,11 +494,27 @@ cycles:
               - stream_1 [date: 2026-03-01 00:00:00]
               - stream_2 [date: 2026-03-01 00:00:00]
               - icon_restart [date: 2026-03-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2026-03-01 00:00:00]:
             input:
               - stream_1 [date: 2026-03-01 00:00:00]
             output:
               - postout_1 [date: 2026-03-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2026-03-01 00:00:00]:
             input:
               - postout_1 [date: 2026-03-01 00:00:00]
@@ -257,6 +522,14 @@ cycles:
               - icon_input [date: 2026-03-01 00:00:00]
             output:
               - stored_data_1 [date: 2026-03-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2026-05-01 00:00:00]:
       tasks:
         - preproc [date: 2026-05-01 00:00:00]:
@@ -268,6 +541,15 @@ cycles:
               - icon_input [date: 2026-05-01 00:00:00]
             wait on:
               - icon [date: 2026-01-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2026-05-01 00:00:00]:
             input:
               - grid_file
@@ -277,11 +559,27 @@ cycles:
               - stream_1 [date: 2026-05-01 00:00:00]
               - stream_2 [date: 2026-05-01 00:00:00]
               - icon_restart [date: 2026-05-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2026-05-01 00:00:00]:
             input:
               - stream_1 [date: 2026-05-01 00:00:00]
             output:
               - postout_1 [date: 2026-05-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2026-05-01 00:00:00]:
             input:
               - postout_1 [date: 2026-05-01 00:00:00]
@@ -289,6 +587,14 @@ cycles:
               - icon_input [date: 2026-05-01 00:00:00]
             output:
               - stored_data_1 [date: 2026-05-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2026-07-01 00:00:00]:
       tasks:
         - preproc [date: 2026-07-01 00:00:00]:
@@ -300,6 +606,15 @@ cycles:
               - icon_input [date: 2026-07-01 00:00:00]
             wait on:
               - icon [date: 2026-03-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2026-07-01 00:00:00]:
             input:
               - grid_file
@@ -309,11 +624,27 @@ cycles:
               - stream_1 [date: 2026-07-01 00:00:00]
               - stream_2 [date: 2026-07-01 00:00:00]
               - icon_restart [date: 2026-07-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2026-07-01 00:00:00]:
             input:
               - stream_1 [date: 2026-07-01 00:00:00]
             output:
               - postout_1 [date: 2026-07-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2026-07-01 00:00:00]:
             input:
               - postout_1 [date: 2026-07-01 00:00:00]
@@ -321,6 +652,14 @@ cycles:
               - icon_input [date: 2026-07-01 00:00:00]
             output:
               - stored_data_1 [date: 2026-07-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2026-09-01 00:00:00]:
       tasks:
         - preproc [date: 2026-09-01 00:00:00]:
@@ -332,6 +671,15 @@ cycles:
               - icon_input [date: 2026-09-01 00:00:00]
             wait on:
               - icon [date: 2026-05-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2026-09-01 00:00:00]:
             input:
               - grid_file
@@ -341,11 +689,27 @@ cycles:
               - stream_1 [date: 2026-09-01 00:00:00]
               - stream_2 [date: 2026-09-01 00:00:00]
               - icon_restart [date: 2026-09-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2026-09-01 00:00:00]:
             input:
               - stream_1 [date: 2026-09-01 00:00:00]
             output:
               - postout_1 [date: 2026-09-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2026-09-01 00:00:00]:
             input:
               - postout_1 [date: 2026-09-01 00:00:00]
@@ -353,6 +717,14 @@ cycles:
               - icon_input [date: 2026-09-01 00:00:00]
             output:
               - stored_data_1 [date: 2026-09-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - icon_bimonthly [date: 2026-11-01 00:00:00]:
       tasks:
         - preproc [date: 2026-11-01 00:00:00]:
@@ -364,6 +736,15 @@ cycles:
               - icon_input [date: 2026-11-01 00:00:00]
             wait on:
               - icon [date: 2026-07-01 00:00:00]
+            name: 'preproc'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 4
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/cleanup.sh'
+            command option: ''
+            input arg options: {'grid_file': '-g', 'extpar_file': '-p', 'ERA5': '-e'}
         - icon [date: 2026-11-01 00:00:00]:
             input:
               - grid_file
@@ -373,11 +754,27 @@ cycles:
               - stream_1 [date: 2026-11-01 00:00:00]
               - stream_2 [date: 2026-11-01 00:00:00]
               - icon_restart [date: 2026-11-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            plugin: 'icon'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 40
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            namelists: {'master': 'path/to/mater_nml', 'model': 'path/to/model_nml'}
         - postproc_1 [date: 2026-11-01 00:00:00]:
             input:
               - stream_1 [date: 2026-11-01 00:00:00]
             output:
               - postout_1 [date: 2026-11-01 00:00:00]
+            name: 'postproc_1'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_ocn.sh'
+            command option: ''
+            input arg options: {'stream_1': '--input'}
         - store_and_clean_1 [date: 2026-11-01 00:00:00]:
             input:
               - postout_1 [date: 2026-11-01 00:00:00]
@@ -385,6 +782,14 @@ cycles:
               - icon_input [date: 2026-11-01 00:00:00]
             output:
               - stored_data_1 [date: 2026-11-01 00:00:00]
+            name: 'store_and_clean_1'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_1': '--input', 'stream_1': '--stream', 'icon_input': '--icon_input'}
   - yearly [date: 2025-01-01 00:00:00]:
       tasks:
         - postproc_2 [date: 2025-01-01 00:00:00]:
@@ -397,6 +802,16 @@ cycles:
               - stream_2 [date: 2025-11-01 00:00:00]
             output:
               - postout_2 [date: 2025-01-01 00:00:00]
+            name: 'postproc_2'
+            coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_atm.sh'
+            command option: ''
+            input arg options: {'stream_2': '--input'}
+            src: 'path/to/src/dir'
         - store_and_clean_2 [date: 2025-01-01 00:00:00]:
             input:
               - postout_2 [date: 2025-01-01 00:00:00]
@@ -408,6 +823,14 @@ cycles:
               - stream_2 [date: 2025-11-01 00:00:00]
             output:
               - stored_data_2 [date: 2025-01-01 00:00:00]
+            name: 'store_and_clean_2'
+            coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_2': '--input'}
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
         - postproc_2 [date: 2026-01-01 00:00:00]:
@@ -420,6 +843,16 @@ cycles:
               - stream_2 [date: 2026-11-01 00:00:00]
             output:
               - postout_2 [date: 2026-01-01 00:00:00]
+            name: 'postproc_2'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
+            nodes: 2
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/main_script_atm.sh'
+            command option: ''
+            input arg options: {'stream_2': '--input'}
+            src: 'path/to/src/dir'
         - store_and_clean_2 [date: 2026-01-01 00:00:00]:
             input:
               - postout_2 [date: 2026-01-01 00:00:00]
@@ -431,3 +864,11 @@ cycles:
               - stream_2 [date: 2026-11-01 00:00:00]
             output:
               - stored_data_2 [date: 2026-01-01 00:00:00]
+            name: 'store_and_clean_2'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            nodes: 1
+            walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
+            command: '$PWD/examples/files/scripts/post_clean.sh'
+            command option: ''
+            input arg options: {'postout_2': '--input'}

--- a/tests/files/data/test_config_parameters.txt
+++ b/tests/files/data/test_config_parameters.txt
@@ -8,6 +8,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - initial conditions
@@ -15,6 +21,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - initial conditions
@@ -22,6 +34,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - initial conditions
@@ -29,6 +47,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - initial conditions
@@ -36,6 +60,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - initial conditions
@@ -43,6 +73,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2026-01-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
@@ -50,6 +86,12 @@ cycles:
               - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2026-01-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
@@ -57,12 +99,24 @@ cycles:
               - icon_output [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2026-01-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2026-01-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
         - icon [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]:
@@ -72,6 +126,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2026-01-01 00:00:00, foo: 0, bar: 3.5]
@@ -79,6 +139,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
@@ -86,6 +152,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.5]
@@ -93,6 +165,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.0]
@@ -100,6 +178,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2026-01-01 00:00:00, foo: 2, bar: 3.5]
@@ -107,6 +191,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2026-03-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.0]
@@ -114,6 +204,12 @@ cycles:
               - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2026-03-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
@@ -121,12 +217,24 @@ cycles:
               - icon_output [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2026-03-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2026-03-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2026-03-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
         - icon [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]:
@@ -136,6 +244,12 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2026-03-01 00:00:00, foo: 0, bar: 3.5]
@@ -143,6 +257,12 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.0]
@@ -150,6 +270,12 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2026-03-01 00:00:00, foo: 1, bar: 3.5]
@@ -157,6 +283,12 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.0]
@@ -164,6 +296,12 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2026-03-01 00:00:00, foo: 2, bar: 3.5]
@@ -171,6 +309,12 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2026-05-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.0]
@@ -178,6 +322,12 @@ cycles:
               - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2026-05-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
@@ -185,12 +335,24 @@ cycles:
               - icon_output [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2026-05-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2026-05-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2026-05-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2026-07-01 00:00:00]:
       tasks:
         - icon [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]:
@@ -200,6 +362,12 @@ cycles:
             output:
               - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2026-05-01 00:00:00, foo: 0, bar: 3.5]
@@ -207,6 +375,12 @@ cycles:
             output:
               - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.0]
@@ -214,6 +388,12 @@ cycles:
             output:
               - icon_output [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2026-05-01 00:00:00, foo: 1, bar: 3.5]
@@ -221,6 +401,12 @@ cycles:
             output:
               - icon_output [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.0]
@@ -228,6 +414,12 @@ cycles:
             output:
               - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2026-05-01 00:00:00, foo: 2, bar: 3.5]
@@ -235,6 +427,12 @@ cycles:
             output:
               - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2026-07-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
@@ -242,6 +440,12 @@ cycles:
               - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2026-07-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
@@ -249,12 +453,24 @@ cycles:
               - icon_output [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2026-07-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2026-07-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2026-09-01 00:00:00]:
       tasks:
         - icon [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]:
@@ -264,6 +480,12 @@ cycles:
             output:
               - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2026-07-01 00:00:00, foo: 0, bar: 3.5]
@@ -271,6 +493,12 @@ cycles:
             output:
               - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
@@ -278,6 +506,12 @@ cycles:
             output:
               - icon_output [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.5]
@@ -285,6 +519,12 @@ cycles:
             output:
               - icon_output [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.0]
@@ -292,6 +532,12 @@ cycles:
             output:
               - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2026-07-01 00:00:00, foo: 2, bar: 3.5]
@@ -299,6 +545,12 @@ cycles:
             output:
               - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2026-09-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.0]
@@ -306,6 +558,12 @@ cycles:
               - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2026-09-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
@@ -313,12 +571,24 @@ cycles:
               - icon_output [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2026-09-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2026-09-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2026-09-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2026-11-01 00:00:00]:
       tasks:
         - icon [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]:
@@ -328,6 +598,12 @@ cycles:
             output:
               - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2026-09-01 00:00:00, foo: 0, bar: 3.5]
@@ -335,6 +611,12 @@ cycles:
             output:
               - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.0]
@@ -342,6 +624,12 @@ cycles:
             output:
               - icon_output [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2026-09-01 00:00:00, foo: 1, bar: 3.5]
@@ -349,6 +637,12 @@ cycles:
             output:
               - icon_output [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.0]
@@ -356,6 +650,12 @@ cycles:
             output:
               - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2026-09-01 00:00:00, foo: 2, bar: 3.5]
@@ -363,6 +663,12 @@ cycles:
             output:
               - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2026-11-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.0]
@@ -370,6 +676,12 @@ cycles:
               - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2026-11-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
@@ -377,12 +689,24 @@ cycles:
               - icon_output [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2026-11-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2026-11-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2026-11-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2027-01-01 00:00:00]:
       tasks:
         - icon [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]:
@@ -392,6 +716,12 @@ cycles:
             output:
               - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2026-11-01 00:00:00, foo: 0, bar: 3.5]
@@ -399,6 +729,12 @@ cycles:
             output:
               - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.0]
@@ -406,6 +742,12 @@ cycles:
             output:
               - icon_output [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2026-11-01 00:00:00, foo: 1, bar: 3.5]
@@ -413,6 +755,12 @@ cycles:
             output:
               - icon_output [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.0]
@@ -420,6 +768,12 @@ cycles:
             output:
               - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2026-11-01 00:00:00, foo: 2, bar: 3.5]
@@ -427,6 +781,12 @@ cycles:
             output:
               - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2027-01-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
@@ -434,6 +794,12 @@ cycles:
               - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2027-01-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
@@ -441,12 +807,24 @@ cycles:
               - icon_output [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2027-01-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2027-01-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2027-03-01 00:00:00]:
       tasks:
         - icon [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]:
@@ -456,6 +834,12 @@ cycles:
             output:
               - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2027-01-01 00:00:00, foo: 0, bar: 3.5]
@@ -463,6 +847,12 @@ cycles:
             output:
               - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
@@ -470,6 +860,12 @@ cycles:
             output:
               - icon_output [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.5]
@@ -477,6 +873,12 @@ cycles:
             output:
               - icon_output [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.0]
@@ -484,6 +886,12 @@ cycles:
             output:
               - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2027-01-01 00:00:00, foo: 2, bar: 3.5]
@@ -491,6 +899,12 @@ cycles:
             output:
               - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2027-03-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.0]
@@ -498,6 +912,12 @@ cycles:
               - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2027-03-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
@@ -505,12 +925,24 @@ cycles:
               - icon_output [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2027-03-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2027-03-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2027-03-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2027, 3, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2027-05-01 00:00:00]:
       tasks:
         - icon [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]:
@@ -520,6 +952,12 @@ cycles:
             output:
               - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2027-03-01 00:00:00, foo: 0, bar: 3.5]
@@ -527,6 +965,12 @@ cycles:
             output:
               - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.0]
@@ -534,6 +978,12 @@ cycles:
             output:
               - icon_output [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2027-03-01 00:00:00, foo: 1, bar: 3.5]
@@ -541,6 +991,12 @@ cycles:
             output:
               - icon_output [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.0]
@@ -548,6 +1004,12 @@ cycles:
             output:
               - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2027-03-01 00:00:00, foo: 2, bar: 3.5]
@@ -555,6 +1017,12 @@ cycles:
             output:
               - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2027-05-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.0]
@@ -562,6 +1030,12 @@ cycles:
               - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2027-05-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
@@ -569,12 +1043,24 @@ cycles:
               - icon_output [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2027-05-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2027-05-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2027-05-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2027, 5, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2027-07-01 00:00:00]:
       tasks:
         - icon [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]:
@@ -584,6 +1070,12 @@ cycles:
             output:
               - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2027-05-01 00:00:00, foo: 0, bar: 3.5]
@@ -591,6 +1083,12 @@ cycles:
             output:
               - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.0]
@@ -598,6 +1096,12 @@ cycles:
             output:
               - icon_output [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2027-05-01 00:00:00, foo: 1, bar: 3.5]
@@ -605,6 +1109,12 @@ cycles:
             output:
               - icon_output [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.0]
@@ -612,6 +1122,12 @@ cycles:
             output:
               - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2027-05-01 00:00:00, foo: 2, bar: 3.5]
@@ -619,6 +1135,12 @@ cycles:
             output:
               - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2027-07-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
@@ -626,6 +1148,12 @@ cycles:
               - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2027-07-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
@@ -633,12 +1161,24 @@ cycles:
               - icon_output [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2027-07-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2027-07-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2027-09-01 00:00:00]:
       tasks:
         - icon [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]:
@@ -648,6 +1188,12 @@ cycles:
             output:
               - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2027-07-01 00:00:00, foo: 0, bar: 3.5]
@@ -655,6 +1201,12 @@ cycles:
             output:
               - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]
@@ -662,6 +1214,12 @@ cycles:
             output:
               - icon_output [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2027-07-01 00:00:00, foo: 1, bar: 3.5]
@@ -669,6 +1227,12 @@ cycles:
             output:
               - icon_output [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.0]
@@ -676,6 +1240,12 @@ cycles:
             output:
               - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2027-07-01 00:00:00, foo: 2, bar: 3.5]
@@ -683,6 +1253,12 @@ cycles:
             output:
               - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2027-09-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.0]
@@ -690,6 +1266,12 @@ cycles:
               - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2027-09-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
@@ -697,12 +1279,24 @@ cycles:
               - icon_output [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2027-09-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2027-09-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2027-09-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2027, 9, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - bimonthly_tasks [date: 2027-11-01 00:00:00]:
       tasks:
         - icon [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]:
@@ -712,6 +1306,12 @@ cycles:
             output:
               - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]
               - icon_restart [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'foo': 0, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]:
             input:
               - icon_restart [date: 2027-09-01 00:00:00, foo: 0, bar: 3.5]
@@ -719,6 +1319,12 @@ cycles:
             output:
               - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]
               - icon_restart [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'foo': 0, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.0]
@@ -726,6 +1332,12 @@ cycles:
             output:
               - icon_output [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]
               - icon_restart [date: 2027-11-01 00:00:00, foo: 1, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'foo': 1, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]:
             input:
               - icon_restart [date: 2027-09-01 00:00:00, foo: 1, bar: 3.5]
@@ -733,6 +1345,12 @@ cycles:
             output:
               - icon_output [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]
               - icon_restart [date: 2027-11-01 00:00:00, foo: 1, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'foo': 1, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]:
             input:
               - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.0]
@@ -740,6 +1358,12 @@ cycles:
             output:
               - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]
               - icon_restart [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'foo': 2, 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - icon [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]:
             input:
               - icon_restart [date: 2027-09-01 00:00:00, foo: 2, bar: 3.5]
@@ -747,6 +1371,12 @@ cycles:
             output:
               - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]
               - icon_restart [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'foo': 2, 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
         - statistics_foo [date: 2027-11-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.0]
@@ -754,6 +1384,12 @@ cycles:
               - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.0]
             output:
               - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.0]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'bar': 3.0}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo [date: 2027-11-01 00:00:00, bar: 3.5]:
             input:
               - icon_output [date: 2027-11-01 00:00:00, foo: 0, bar: 3.5]
@@ -761,12 +1397,24 @@ cycles:
               - icon_output [date: 2027-11-01 00:00:00, foo: 2, bar: 3.5]
             output:
               - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.5]
+            name: 'statistics_foo'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0), 'bar': 3.5}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
         - statistics_foo_bar [date: 2027-11-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.5]
               - analysis_foo [date: 2027-11-01 00:00:00, bar: 3.0]
             output:
               - analysis_foo_bar [date: 2027-11-01 00:00:00]
+            name: 'statistics_foo_bar'
+            coordinates: {'date': datetime.datetime(2027, 11, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/statistics.py'
+            command option: ''
+            input arg options: {}
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
         - merge [date: 2026-01-01 00:00:00]:
@@ -779,6 +1427,12 @@ cycles:
               - analysis_foo_bar [date: 2026-11-01 00:00:00]
             output:
               - yearly_analysis [date: 2026-01-01 00:00:00]
+            name: 'merge'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/merge.py'
+            command option: ''
+            input arg options: {}
   - yearly [date: 2027-01-01 00:00:00]:
       tasks:
         - merge [date: 2027-01-01 00:00:00]:
@@ -791,3 +1445,9 @@ cycles:
               - analysis_foo_bar [date: 2027-11-01 00:00:00]
             output:
               - yearly_analysis [date: 2027-01-01 00:00:00]
+            name: 'merge'
+            coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/merge.py'
+            command option: ''
+            input arg options: {}

--- a/tests/files/data/test_config_small.txt
+++ b/tests/files/data/test_config_small.txt
@@ -5,6 +5,12 @@ cycles:
             output:
               - icon_output [date: 2026-01-01 00:00:00]
               - icon_restart [date: 2026-01-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
         - icon [date: 2026-03-01 00:00:00]:
@@ -13,6 +19,12 @@ cycles:
             output:
               - icon_output [date: 2026-03-01 00:00:00]
               - icon_restart [date: 2026-03-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
         - icon [date: 2026-05-01 00:00:00]:
@@ -21,8 +33,20 @@ cycles:
             output:
               - icon_output [date: 2026-05-01 00:00:00]
               - icon_restart [date: 2026-05-01 00:00:00]
+            name: 'icon'
+            coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/icon.py'
+            command option: ''
+            input arg options: {'icon_restart': '--restart'}
   - lastly:
       tasks:
         - cleanup:
             wait on:
               - icon [date: 2026-05-01 00:00:00]
+            name: 'cleanup'
+            coordinates: {}
+            plugin: 'shell'
+            command: '$PWD/tests/files/scripts/cleanup.py'
+            command option: ''
+            input arg options: {}


### PR DESCRIPTION
The parameters specified in the config file corresponding to specific task plugins file are now passed to their corresponding classes in core. ShellTask and IconTask. For that pydantic discrimantors are used. See for more information
https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions-with-callable-discriminator

To test the new changes formatting of represented member variables has been added to the formatting of `core.Task` objects.

Documentation to the `core.Plugin` has been added and the class has been renamed to `core.TaskPlugin`.