### PR TITLE
Replace `cli_arguments` in the yaml to a single string

### DIFF
--- a/tests/cases/large/config/test_config_large.yml
+++ b/tests/cases/large/config/test_config_large.yml
@@ -62,11 +62,7 @@ tasks:
   - extpar:
       plugin: shell  # no extpar plugin available yet
       command: $PWD/examples/files/scripts/extpar
-      cli_arguments:
-        keyword:
-          --input: obs_data
-        flags:
-          - --verbose
+      cli_arguments: "--verbose {--input obs_data}"
       uenv:
         squashfs: path/to/squashfs
         mount_point: runtime/mount/point
@@ -75,13 +71,8 @@ tasks:
   - preproc:
       plugin: shell
       command: $PWD/examples/files/scripts/cleanup.sh
-      cli_arguments:
-        positional:
-          - grid_file
-        keyword:
-          -p: extpar_file
-          -e: ERA5
-        source_file: dummy_source_file
+      cli_arguments: "{-p extpar_file} {-e ERA5} {grid_file}"
+      env_source_files: $PWD/examples/files/data/dummy_source_file.sh
       nodes: 4
       walltime: 00:02:00
       uenv:
@@ -90,10 +81,7 @@ tasks:
   - icon:
       plugin: icon
       command: $PWD/examples/files/scripts/icon
-      cli_arguments:
-        keyword:
-          -g: grid_file
-          --input: icon_input
+      cli_arguments: "{-g grid_file} {--input icon_input}"
       nodes: 40
       walltime: 23:59:59
       namelists:
@@ -105,9 +93,7 @@ tasks:
   - postproc_1:
       plugin: shell
       command: $PWD/examples/files/scripts/main_script_ocn.sh
-      cli_arguments:
-        keyword:
-          --input: stream_1
+      cli_arguments: "{--input stream_1}"
       nodes: 2
       walltime: 00:05:00
       uenv:
@@ -116,12 +102,7 @@ tasks:
   - postproc_2:
       plugin: shell
       command: $PWD/examples/files/scripts/main_script_atm.sh
-      cli_arguments:
-        keyword:
-          --input: stream_2
-          # `arg_option` should be in `tasks` section instead
-          # How to implement this? Even needed with keyword-arguments?
-          # arg_option: --input
+      cli_arguments: "{--input stream_2}"
       nodes: 2
       walltime: 00:05:00
       src: path/to/src/dir
@@ -131,19 +112,13 @@ tasks:
   - store_and_clean_1:
       plugin: shell
       command: $PWD/examples/files/scripts/post_clean.sh
-      cli_arguments:
-        keyword:
-          --input: postout_1
-          --stream: stream_1
-          --icon_input: icon_input
+      cli_arguments: "{--input postout_1} {--stream stream_1} {--icon_input icon_input}"
       nodes: 1
       walltime: 00:01:00
   - store_and_clean_2:
       plugin: shell
       command: $PWD/examples/files/scripts/post_clean.sh
-      cli_arguments:
-        keyword:
-          --input: postout_2
+      cli_arguments: "{--input postout_2}"
       nodes: 1
       walltime: 00:01:00
 data:
@@ -157,9 +132,6 @@ data:
     - ERA5:
         type: file
         src: $PWD/examples/files/data/era5
-    - dummy_source_file:
-        type: file
-        src: $PWD/examples/files/data/dummy_source_file.sh
   generated:
     - extpar_file:
         type: file

--- a/tests/cases/large/data/test_config_large.txt
+++ b/tests/cases/large/data/test_config_large.txt
@@ -13,7 +13,8 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/extpar'
-            cli arguments: positional=None keyword={'--input': 'obs_data'} flags=['--verbose'] source_file=None
+            cli arguments: [ShellCliArgument(name='--verbose', references_data_item=False, cli_option_of_data_item=None), ShellCliArgument(name='obs_data', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
   - icon_bimonthly [date: 2025-01-01 00:00:00]:
       tasks:
         - preproc [date: 2025-01-01 00:00:00]:
@@ -32,7 +33,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2025-01-01 00:00:00]:
             input:
               - grid_file
@@ -64,7 +66,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2025-01-01 00:00:00]:
             input:
               - postout_1 [date: 2025-01-01 00:00:00]
@@ -80,7 +83,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2025-03-01 00:00:00]:
       tasks:
         - preproc [date: 2025-03-01 00:00:00]:
@@ -99,7 +103,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2025-03-01 00:00:00]:
             input:
               - grid_file
@@ -132,7 +137,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2025-03-01 00:00:00]:
             input:
               - postout_1 [date: 2025-03-01 00:00:00]
@@ -148,7 +154,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2025-05-01 00:00:00]:
       tasks:
         - preproc [date: 2025-05-01 00:00:00]:
@@ -169,7 +176,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2025-05-01 00:00:00]:
             input:
               - grid_file
@@ -202,7 +210,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2025-05-01 00:00:00]:
             input:
               - postout_1 [date: 2025-05-01 00:00:00]
@@ -218,7 +227,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2025-07-01 00:00:00]:
       tasks:
         - preproc [date: 2025-07-01 00:00:00]:
@@ -239,7 +249,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2025-07-01 00:00:00]:
             input:
               - grid_file
@@ -272,7 +283,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2025-07-01 00:00:00]:
             input:
               - postout_1 [date: 2025-07-01 00:00:00]
@@ -288,7 +300,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2025-09-01 00:00:00]:
       tasks:
         - preproc [date: 2025-09-01 00:00:00]:
@@ -309,7 +322,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2025-09-01 00:00:00]:
             input:
               - grid_file
@@ -342,7 +356,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2025-09-01 00:00:00]:
             input:
               - postout_1 [date: 2025-09-01 00:00:00]
@@ -358,7 +373,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2025-11-01 00:00:00]:
       tasks:
         - preproc [date: 2025-11-01 00:00:00]:
@@ -379,7 +395,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2025-11-01 00:00:00]:
             input:
               - grid_file
@@ -412,7 +429,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2025-11-01 00:00:00]:
             input:
               - postout_1 [date: 2025-11-01 00:00:00]
@@ -428,7 +446,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2026-01-01 00:00:00]:
       tasks:
         - preproc [date: 2026-01-01 00:00:00]:
@@ -449,7 +468,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2026-01-01 00:00:00]:
             input:
               - grid_file
@@ -482,7 +502,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2026-01-01 00:00:00]:
             input:
               - postout_1 [date: 2026-01-01 00:00:00]
@@ -498,7 +519,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2026-03-01 00:00:00]:
       tasks:
         - preproc [date: 2026-03-01 00:00:00]:
@@ -519,7 +541,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2026-03-01 00:00:00]:
             input:
               - grid_file
@@ -552,7 +575,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2026-03-01 00:00:00]:
             input:
               - postout_1 [date: 2026-03-01 00:00:00]
@@ -568,7 +592,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2026-05-01 00:00:00]:
       tasks:
         - preproc [date: 2026-05-01 00:00:00]:
@@ -589,7 +614,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2026-05-01 00:00:00]:
             input:
               - grid_file
@@ -622,7 +648,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2026-05-01 00:00:00]:
             input:
               - postout_1 [date: 2026-05-01 00:00:00]
@@ -638,7 +665,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2026-07-01 00:00:00]:
       tasks:
         - preproc [date: 2026-07-01 00:00:00]:
@@ -659,7 +687,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2026-07-01 00:00:00]:
             input:
               - grid_file
@@ -692,7 +721,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2026-07-01 00:00:00]:
             input:
               - postout_1 [date: 2026-07-01 00:00:00]
@@ -708,7 +738,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2026-09-01 00:00:00]:
       tasks:
         - preproc [date: 2026-09-01 00:00:00]:
@@ -729,7 +760,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2026-09-01 00:00:00]:
             input:
               - grid_file
@@ -762,7 +794,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2026-09-01 00:00:00]:
             input:
               - postout_1 [date: 2026-09-01 00:00:00]
@@ -778,7 +811,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - icon_bimonthly [date: 2026-11-01 00:00:00]:
       tasks:
         - preproc [date: 2026-11-01 00:00:00]:
@@ -799,7 +833,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/cleanup.sh'
-            cli arguments: positional=['grid_file'] keyword={'-p': 'extpar_file', '-e': 'ERA5'} flags=None source_file='dummy_source_file'
+            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            env source files: ['$PWD/examples/files/data/dummy_source_file.sh']
         - icon [date: 2026-11-01 00:00:00]:
             input:
               - grid_file
@@ -832,7 +867,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_ocn.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_1'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
         - store_and_clean_1 [date: 2026-11-01 00:00:00]:
             input:
               - postout_1 [date: 2026-11-01 00:00:00]
@@ -848,7 +884,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_1', '--stream': 'stream_1', '--icon_input': 'icon_input'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            env source files: []
   - yearly [date: 2025-01-01 00:00:00]:
       tasks:
         - postproc_2 [date: 2025-01-01 00:00:00]:
@@ -870,7 +907,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_atm.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_2'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_2', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
             src: 'path/to/src/dir'
         - store_and_clean_2 [date: 2025-01-01 00:00:00]:
             input:
@@ -891,7 +929,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_2'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_2', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
         - postproc_2 [date: 2026-01-01 00:00:00]:
@@ -913,7 +952,8 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/main_script_atm.sh'
-            cli arguments: positional=None keyword={'--input': 'stream_2'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='stream_2', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []
             src: 'path/to/src/dir'
         - store_and_clean_2 [date: 2026-01-01 00:00:00]:
             input:
@@ -934,4 +974,5 @@ cycles:
             end date: 2027-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/examples/files/scripts/post_clean.sh'
-            cli arguments: positional=None keyword={'--input': 'postout_2'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='postout_2', references_data_item=True, cli_option_of_data_item='--input')]
+            env source files: []

--- a/tests/cases/parameters/config/test_config_parameters.yml
+++ b/tests/cases/parameters/config/test_config_parameters.yml
@@ -46,9 +46,7 @@ tasks:
   - icon:
       plugin: shell
       command: $PWD/tests/files/scripts/icon.py
-      cli_arguments:
-        keyword:
-          --restart: icon_restart
+      cli_arguments: "{--restart icon_restart} {--init initial_conditions} {--forcing forcing}"
       parameters: [foo, bar]
   - statistics_foo:
       plugin: shell

--- a/tests/cases/parameters/data/test_config_parameters.txt
+++ b/tests/cases/parameters/data/test_config_parameters.txt
@@ -14,7 +14,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - icon [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - initial conditions
@@ -28,7 +29,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - statistics_foo [date: 2026-01-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-01-01 00:00:00, foo: 0, bar: 3.0]
@@ -41,6 +43,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
         - statistics_foo_bar [date: 2026-01-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-01-01 00:00:00, bar: 3.0]
@@ -52,6 +56,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
   - bimonthly_tasks [date: 2026-07-01 00:00:00]:
       tasks:
         - icon [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]:
@@ -67,7 +73,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - icon [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-01-01 00:00:00, foo: 1, bar: 3.0]
@@ -81,7 +88,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - statistics_foo [date: 2026-07-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2026-07-01 00:00:00, foo: 0, bar: 3.0]
@@ -94,6 +102,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
         - statistics_foo_bar [date: 2026-07-01 00:00:00]:
             input:
               - analysis_foo [date: 2026-07-01 00:00:00, bar: 3.0]
@@ -105,6 +115,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
   - bimonthly_tasks [date: 2027-01-01 00:00:00]:
       tasks:
         - icon [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]:
@@ -120,7 +132,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - icon [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2026-07-01 00:00:00, foo: 1, bar: 3.0]
@@ -134,7 +147,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - statistics_foo [date: 2027-01-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-01-01 00:00:00, foo: 0, bar: 3.0]
@@ -147,6 +161,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
         - statistics_foo_bar [date: 2027-01-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-01-01 00:00:00, bar: 3.0]
@@ -158,6 +174,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
   - bimonthly_tasks [date: 2027-07-01 00:00:00]:
       tasks:
         - icon [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]:
@@ -173,7 +191,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - icon [date: 2027-07-01 00:00:00, foo: 1, bar: 3.0]:
             input:
               - icon_restart [date: 2027-01-01 00:00:00, foo: 1, bar: 3.0]
@@ -187,7 +206,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            env source files: []
         - statistics_foo [date: 2027-07-01 00:00:00, bar: 3.0]:
             input:
               - icon_output [date: 2027-07-01 00:00:00, foo: 0, bar: 3.0]
@@ -200,6 +220,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
         - statistics_foo_bar [date: 2027-07-01 00:00:00]:
             input:
               - analysis_foo [date: 2027-07-01 00:00:00, bar: 3.0]
@@ -211,6 +233,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/statistics.py'
+            cli arguments: []
+            env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
         - merge [date: 2026-01-01 00:00:00]:
@@ -225,6 +249,8 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/merge.py'
+            cli arguments: []
+            env source files: []
   - yearly [date: 2027-01-01 00:00:00]:
       tasks:
         - merge [date: 2027-01-01 00:00:00]:
@@ -239,3 +265,5 @@ cycles:
             end date: 2028-01-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/merge.py'
+            cli arguments: []
+            env source files: []

--- a/tests/cases/small/config/test_config_small.yml
+++ b/tests/cases/small/config/test_config_small.yml
@@ -24,9 +24,7 @@ tasks:
   - icon:
       plugin: shell
       command: $PWD/tests/files/scripts/icon.py
-      cli_arguments:
-        keyword:
-          --restart: icon_restart
+      cli_arguments: "{--restart icon_restart} {--init initial_conditions}"
   - cleanup:
       plugin: shell
       command: $PWD/tests/files/scripts/cleanup.py

--- a/tests/cases/small/data/test_config_small.txt
+++ b/tests/cases/small/data/test_config_small.txt
@@ -11,7 +11,8 @@ cycles:
             end date: 2026-06-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init')]
+            env source files: []
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
         - icon [date: 2026-03-01 00:00:00]:
@@ -26,7 +27,8 @@ cycles:
             end date: 2026-06-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init')]
+            env source files: []
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
         - icon [date: 2026-05-01 00:00:00]:
@@ -41,7 +43,8 @@ cycles:
             end date: 2026-06-01 00:00:00
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/icon.py'
-            cli arguments: positional=None keyword={'--restart': 'icon_restart'} flags=None source_file=None
+            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init')]
+            env source files: []
   - lastly:
       tasks:
         - cleanup:
@@ -51,3 +54,5 @@ cycles:
             coordinates: {}
             plugin: 'shell'
             command: '$PWD/tests/files/scripts/cleanup.py'
+            cli arguments: []
+            env source files: []

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -3,8 +3,25 @@ from pathlib import Path
 import pytest
 
 from sirocco.core import Workflow
+from sirocco.parsing._yaml_data_models import ConfigShellTask, ShellCliArgument
 from sirocco.pretty_print import PrettyPrinter
 from sirocco.vizgraph import VizGraph
+
+
+# configs that are tested for parsing
+def test_parsing_cli_parameters():
+    cli_arguments = "-D --CMAKE_CXX_COMPILER=${CXX_COMPILER} {--init file}"
+    assert ConfigShellTask.split_cli_arguments(cli_arguments) == [
+        "-D",
+        "--CMAKE_CXX_COMPILER=${CXX_COMPILER}",
+        "{--init file}",
+    ]
+
+    assert ConfigShellTask.parse_cli_arguments(cli_arguments) == [
+        ShellCliArgument("-D", False, None),
+        ShellCliArgument("--CMAKE_CXX_COMPILER=${CXX_COMPILER}", False, None),
+        ShellCliArgument("file", True, "--init"),
+    ]
 
 
 @pytest.fixture
@@ -35,8 +52,9 @@ def test_parse_config_file(config_paths, pprinter):
     if test_str != reference_str:
         new_path = Path(config_paths["txt"]).with_suffix(".new.txt")
         new_path.write_text(test_str)
-        msg = f"Workflow graph doesn't match serialized data. New graph string dumped to {new_path}."
-        raise ValueError(msg)
+        assert (
+            reference_str == test_str
+        ), f"Workflow graph doesn't match serialized data. New graph string dumped to {new_path}."
 
 
 @pytest.mark.skip(reason="don't run it each time, uncomment to regenerate serilaized data")


### PR DESCRIPTION
First merge PR #74

When implementing the suggestion from CLI arguments I realized that there is a problem with the association of an option to an argument for input arguments. From the string
`--init {file}` we do not know if the option `--init` is associated with the `file` input or not. This is important since we have time conditions specified with `when` so we can omit certain inputs during a certain time. In the case the option is associated with the input we want to omit both. My solution was to include the option to the string interpolation `{--init file}`. However this makes parsing more cumbersome since we have now a space insinde the curly brackets. We use spaces to split the cli argument into separate entities. In this case we however want both to be together. We also have to consider CLI arguments that use curly brackets for environmental variables `${VAR}_EXTENDED`. For now I implemented In PR #45 that all data inputs have to be specified in the `cli_arguments`. The remaining data inputs which are not specified in the `cli_arguments` are always added as positional arguments in the same order as specified in the yaml file.

