### PR TITLE
Upgrade to aiida-workgraph v0.4.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
   "pydantic",
   "pydantic-yaml",
   "aiida-core>=2.5",
-  "aiida-workgraph==0.3.14",
-  "node_graph==0.0.11",
+  "aiida-workgraph==0.4.10",
   "termcolor",
   "pygraphviz",
   "lxml"

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -85,4 +85,4 @@ def test_run_workgraph(config_path):
     core_workflow = Workflow.from_yaml(config_path)
     aiida_workflow = AiidaWorkGraph(core_workflow)
     out = aiida_workflow.run()
-    assert out.get("execution_count", None).value == 0  # TODO: should be 1 but we need to update workgraph for this
+    assert out.get("execution_count", None).value == 1


### PR DESCRIPTION
Needs to merged after PR #45

To include several bugfixes fwe upgrade to the version v0.4.10. This is required to specify computer in the metadata of the workgraph task as this is not possible with the currently pinned version. The workgraph API has changed therefore we adapt to new API the functions which makes part of the function calls cleaner. The workaround is still needed but has been better documented. Closes issue #76