### PR TITLE
Add option to specify computer for available data items

### DIFF
--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -390,6 +390,7 @@ class ConfigBaseDataSpecs:
     type: str | None = None
     src: str | None = None
     format: str | None = None
+    computer: str | None = None
 
 
 class ConfigBaseData(_NamedBaseModel, ConfigBaseDataSpecs):
@@ -417,7 +418,13 @@ class ConfigAvailableData(ConfigBaseData):
 
 
 class ConfigGeneratedData(ConfigBaseData):
-    pass
+    @field_validator("computer")
+    @classmethod
+    def invalid_field(cls, value: str | None) -> str | None:
+        if value is not None:
+            msg = "The field 'computer' can only be specified for available data."
+            raise ValueError(msg)
+        return value
 
 
 class ConfigData(BaseModel):

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -145,7 +145,14 @@ class AiidaWorkGraph:
         input_path = Path(input_.src)
         input_full_path = input_.src if input_path.is_absolute() else task.config_rootdir / input_path
 
-        if input_.type == "file":
+        if input_.computer is not None:
+            try:
+                computer = aiida.orm.load_computer(input_.computer)
+            except NotExistent as err:
+                msg = f"Could not find computer {input_.computer!r} for input {input_}."
+                raise ValueError(msg) from err
+            self._aiida_data_nodes[label] = aiida.orm.RemoteData(remote_path=input_.src, label=label, computer=computer)
+        elif input_.type == "file":
             self._aiida_data_nodes[label] = aiida.orm.SinglefileData(label=label, file=input_full_path)
         elif input_.type == "dir":
             self._aiida_data_nodes[label] = aiida.orm.FolderData(label=label, tree=input_full_path)

--- a/tests/cases/small/config/test_config_small.yml
+++ b/tests/cases/small/config/test_config_small.yml
@@ -42,6 +42,7 @@ data:
          src: data/input
      - initial_conditions:
          type: file
+         computer: localhost
          src: data/initial_conditions
   generated:
      - icon_output:


### PR DESCRIPTION
Needs #78 to be merged before.

This allows to specify data items that are only remotely available or should not be copied over to the aiida internal folder. I did not add the computer information to the IR because the IR focuses on representing the unrolling/expansion from the config to a graph and the computer information is completely independent from this logic.