### PR TITLE
Example canonicalization for ConfigWorkflow

### DIFF
--- a/src/sirocco/core/workflow.py
+++ b/src/sirocco/core/workflow.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from itertools import product
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
-from sirocco.core import _tasks  # noqa [F401]
 from sirocco.core.graph_items import Cycle, Data, Store, Task
 from sirocco.parsing._yaml_data_models import (
-    ConfigWorkflow,
+    CanonicalWorkflow,
     load_workflow_config,
 )
 
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
 class Workflow:
     """Internal representation of a workflow"""
 
-    def __init__(self, workflow_config: ConfigWorkflow) -> None:
+    def __init__(self, workflow_config: CanonicalWorkflow) -> None:
         self.name = workflow_config.name
         self.tasks = Store()
         self.data = Store()
@@ -68,7 +67,11 @@ class Workflow:
                         self.tasks.add(task)
                         cycle_tasks.append(task)
                 self.cycles.add(
-                    Cycle(name=cycle_name, tasks=cycle_tasks, coordinates={} if date is None else {"date": date})
+                    Cycle(
+                        name=cycle_name,
+                        tasks=cycle_tasks,
+                        coordinates={} if date is None else {"date": date},
+                    )
                 )
 
         # 4 - Link wait on tasks
@@ -83,5 +86,5 @@ class Workflow:
                 yield date
 
     @classmethod
-    def from_yaml(cls, config_path: str):
+    def from_yaml(cls: type[Self], config_path: str) -> Self:
         return cls(load_workflow_config(config_path))

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -379,7 +379,9 @@ class ConfigData(BaseModel):
     generated: list[ConfigGeneratedData] = []
 
 
-def get_plugin_from_named_base_model(data: dict) -> str:
+def get_plugin_from_named_base_model(
+    data: dict | ConfigRootTask | ConfigShellTask | ConfigIconTask,
+) -> str:
     if isinstance(data, (ConfigRootTask, ConfigShellTask, ConfigIconTask)):
         return data.plugin
     name_and_specs = _NamedBaseModel.merge_name_and_specs(data)

--- a/tests/unit_tests/parsing/test_yaml_data_models.py
+++ b/tests/unit_tests/parsing/test_yaml_data_models.py
@@ -1,17 +1,22 @@
+import pathlib
 import textwrap
 
 from sirocco.parsing import _yaml_data_models as models
 
 
-def test_workflow_test_internal_dicts():
-    testee = models.ConfigWorkflow(
-        cycles=[],
+def test_workflow_canonicalization():
+    config = models.ConfigWorkflow(
+        name="testee",
+        rootdir=pathlib.Path("foo"),
+        cycles=[models.ConfigCycle(minimal={"tasks": [models.ConfigCycleTask(a={})]})],
         tasks=[{"some_task": {"plugin": "shell"}}],
         data=models.ConfigData(
             available=[models.ConfigAvailableData(foo={})],
             generated=[models.ConfigGeneratedData(bar={})],
         ),
     )
+
+    testee = models.canonicalize(config)
     assert testee.data_dict["foo"].name == "foo"
     assert testee.data_dict["bar"].name == "bar"
     assert testee.task_dict["some_task"].name == "some_task"


### PR DESCRIPTION
This represents the result of steps 4) - 8) in #88 for `ConfigWorkflow`.

Note how it isolates the tests from syntactic changes in the YAML format, so that only changes in semantics require adapting tests (as I believe they should).

## Changes:

- isolate `ConfigWorkflow` from the need for unit testing by canonicalizing it into `CanonicalWorkflow`, which can be tested in isolation from the actual YAML format.
- move the dictionary building from a validator in `ConfigWorkflow` to the canonicalization function
- adapt unit tests