### PR TITLE
Add computer to `Data` initialization in core

### DIFF
--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -40,6 +40,7 @@ class Data(ConfigBaseDataSpecs, GraphItem):
     def from_config(cls, config: ConfigBaseData, coordinates: dict) -> Self:
         return cls(
             name=config.name,
+            computer=config.computer,
             type=config.type,
             src=config.src,
             available=isinstance(config, ConfigAvailableData),


### PR DESCRIPTION
The `computer` argument from the config class was not correctly passed to the core `Data` class. This is fixed here.

Note that aiida-shell has a bug when using `RemoteData`. This will be fixed here https://github.com/sphuber/aiida-shell/pull/107