### PR TITLE
Support python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         aiida-version: ['stable']
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.10', '3.13']
         aiida-version: ['stable']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   'License :: OSI Approved :: MIT License',
 ]
 keywords = ["workflow"," icon", "aiida", "aiida-workgraph"]
-requires-python = '>=3.12'
+requires-python = '>=3.10'
 dependencies = [
   "numpy",
   "isoduration",


### PR DESCRIPTION
Since python 3.9 will be deprecated this year, I would not bother supporting it, especially because the type hint improvements with 3.10 are much more readable.