### PR TITLE
WIP: By default run tests in tests folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ path = "src/sirocco/__init__.py"
 extra-dependencies = [
     "ipdb"
 ]
-default-args = []
+default-args = ["tests"]
 extra-args = ["--doctest-modules"]
 
 [[tool.hatch.envs.hatch-test.matrix]]


### PR DESCRIPTION
Right now `hatch test` runs also files in top level directory, this is a bit annoying since one needs to specify `hatch test -- tests`. This is not really fixing it, I need to investigate this further.