### PR TITLE
Icon namelist non optional

### DIFF
--- a/src/sirocco/core/_tasks/icon_task.py
+++ b/src/sirocco/core/_tasks/icon_task.py
@@ -10,7 +10,7 @@ from sirocco.core.graph_items import Task
 from sirocco.parsing._yaml_data_models import ConfigIconTaskSpecs
 
 
-@dataclass
+@dataclass(kw_only=True)
 class IconTask(ConfigIconTaskSpecs, Task):
     core_namelists: dict[str, f90nml.Namelist] = field(default_factory=dict)
 

--- a/src/sirocco/core/_tasks/shell_task.py
+++ b/src/sirocco/core/_tasks/shell_task.py
@@ -6,6 +6,6 @@ from sirocco.core.graph_items import Task
 from sirocco.parsing._yaml_data_models import ConfigShellTaskSpecs
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ShellTask(ConfigShellTaskSpecs, Task):
     pass

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -39,7 +39,7 @@ class Data(ConfigBaseDataSpecs, GraphItem):
 
     color: ClassVar[str] = field(default="light_blue", repr=False)
 
-    available: bool | None = None  # must get a default value because of dataclass inheritence
+    available: bool
 
     @classmethod
     def from_config(cls, config: ConfigBaseData, coordinates: dict) -> Self:

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     )
 
 
-@dataclass
+@dataclass(kw_only=True)
 class GraphItem:
     """base class for Data Tasks and Cycles"""
 
@@ -33,7 +33,7 @@ class GraphItem:
     coordinates: dict
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Data(ConfigBaseDataSpecs, GraphItem):
     """Internal representation of a data node"""
 
@@ -56,7 +56,7 @@ class Data(ConfigBaseDataSpecs, GraphItem):
 BoundData: TypeAlias = tuple[Data, str | None]
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Task(ConfigBaseTaskSpecs, GraphItem):
     """Internal representation of a task node"""
 
@@ -129,7 +129,7 @@ class Task(ConfigBaseTaskSpecs, GraphItem):
         )
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Cycle(GraphItem):
     """Internal reprenstation of a cycle"""
 

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -440,25 +440,26 @@ class ConfigIconTaskSpecs:
 class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
     """Class representing an ICON task configuration from a workflow file
 
-        Examples:
+    Examples:
 
-        yaml snippet:
+    yaml snippet:
 
-            >>> import textwrap
-            >>> import pydantic_yaml
-            >>> snippet = textwrap.dedent(
-            ...     '''
-            ...       ICON:
-            ...         plugin: icon
-            ...         namelists:
-            ...           - path/to/icon_master.namelist
-            ...           - path/to/case_nml:
-            ...               block_1:
-            ...                 param_name: param_value
-            ...     '''
-            ... )
-            >>> icon_task_cfg = pydantic_yaml.parse_yaml_raw_as(ConfigIconTask, snippet)
+        >>> import textwrap
+        >>> import pydantic_yaml
+        >>> snippet = textwrap.dedent(
+        ...     '''
+        ...       ICON:
+        ...         plugin: icon
+        ...         namelists:
+        ...           - path/to/icon_master.namelist
+        ...           - path/to/case_nml:
+        ...               block_1:
+        ...                 param_name: param_value
+        ...     '''
+        ... )
+        >>> icon_task_cfg = pydantic_yaml.parse_yaml_raw_as(ConfigIconTask, snippet)
     """
+
     @field_validator("namelists", mode="before")
     @classmethod
     def check_nmls(cls, nmls: dict[str, ConfigNamelist] | list[Any]) -> dict[str, ConfigNamelist]:

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -276,7 +276,7 @@ class ConfigCycle(_NamedBaseModel):
         return self
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ConfigBaseTaskSpecs:
     computer: str | None = None
     host: str | None = None
@@ -349,7 +349,7 @@ class ShellCliArgument:
         return cls(name, references_data_item, cli_option_of_data_item)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ConfigShellTaskSpecs:
     plugin: ClassVar[Literal["shell"]] = "shell"
     command: str = ""
@@ -409,7 +409,7 @@ class ConfigShellTask(ConfigBaseTask, ConfigShellTaskSpecs):
         return [ShellCliArgument.from_cli_argument(arg) for arg in ConfigShellTask.split_cli_arguments(cli_arguments)]
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ConfigNamelist:
     """Class for namelist specifications"""
 
@@ -417,10 +417,10 @@ class ConfigNamelist:
     specs: dict | None = None
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ConfigIconTaskSpecs:
     plugin: ClassVar[Literal["icon"]] = "icon"
-    namelists: dict[str, ConfigNamelist] | None = None
+    namelists: dict[str, ConfigNamelist]
 
 
 class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
@@ -463,6 +463,7 @@ class DataType(enum.StrEnum):
 
 
 @dataclass
+@dataclass(kw_only=True)
 class ConfigBaseDataSpecs:
     type: DataType
     src: str

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -417,14 +417,13 @@ class ConfigNamelist:
     - specs is a dictionnary containing the specifications of parameters
       to change in the original namelist file
 
-    For example:
+    Example:
 
-    ... python
-
-        ConfigNamelist(path="/some/path/to/icon.nml",
-                       specs={"first_nml_block":{"first_param": first_value,
-                                                 "second_param": second_value},
-                              "second_nml_block":{"third_param": third_value}})
+        >>> path="/some/path/to/icon.nml"
+        >>> specs = {"first_nml_block": {"first_param": "a string value",
+        ...                              "second_param": 0},
+        ...          "second_nml_block": {"third_param": False}}
+        >>> config_nml = ConfigNamelist(path=path, specs=specs)
     """
 
     path: Path

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -438,18 +438,39 @@ class ConfigIconTaskSpecs:
 
 
 class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
+    """Class representing an ICON task configuration from a workflow file
+
+        Examples:
+
+        yaml snippet:
+
+            >>> import textwrap
+            >>> import pydantic_yaml
+            >>> snippet = textwrap.dedent(
+            ...     '''
+            ...       ICON:
+            ...         plugin: icon
+            ...         namelists:
+            ...           - path/to/icon_master.namelist
+            ...           - path/to/case_nml:
+            ...               block_1:
+            ...                 param_name: param_value
+            ...     '''
+            ... )
+            >>> icon_task_cfg = pydantic_yaml.parse_yaml_raw_as(ConfigIconTask, snippet)
+    """
     @field_validator("namelists", mode="before")
     @classmethod
-    def check_nml(cls, nml_list: list[Any]) -> dict[str, ConfigNamelist]:
-        if nml_list is None:
-            msg = "ICON tasks need namelists, got none"
-            raise ValueError(msg)
-        if not isinstance(nml_list, list):
-            msg = f"expected a list got type {type(nml_list).__name__}"
+    def check_nmls(cls, nmls: dict[str, ConfigNamelist] | list[Any]) -> dict[str, ConfigNamelist]:
+        # Make validator idempotent even if not used yet
+        if isinstance(nmls, dict):
+            return nmls
+        if not isinstance(nmls, list):
+            msg = f"expected a list got type {type(nmls).__name__}"
             raise TypeError(msg)
         namelists = {}
         master_found = False
-        for nml in nml_list:
+        for nml in nmls:
             msg = f"was expecting a dict of length 1 or a string, got {nml}"
             if not isinstance(nml, (str, dict)):
                 raise TypeError(msg)

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -419,10 +419,11 @@ class ConfigNamelist:
 
     Example:
 
-        >>> path="/some/path/to/icon.nml"
-        >>> specs = {"first_nml_block": {"first_param": "a string value",
-        ...                              "second_param": 0},
-        ...          "second_nml_block": {"third_param": False}}
+        >>> path = "/some/path/to/icon.nml"
+        >>> specs = {
+        ...     "first_nml_block": {"first_param": "a string value", "second_param": 0},
+        ...     "second_nml_block": {"third_param": False},
+        ... }
         >>> config_nml = ConfigNamelist(path=path, specs=specs)
     """
 

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -411,7 +411,21 @@ class ConfigShellTask(ConfigBaseTask, ConfigShellTaskSpecs):
 
 @dataclass(kw_only=True)
 class ConfigNamelist:
-    """Class for namelist specifications"""
+    """Class for namelist specifications
+
+    - path is the path to the namelist file considered as template
+    - specs is a dictionnary containing the specifications of parameters
+      to change in the original namelist file
+
+    For example:
+
+    ... python
+
+        ConfigNamelist(path="/some/path/to/icon.nml",
+                       specs={"first_nml_block":{"first_param": first_value,
+                                                 "second_param": second_value},
+                              "second_nml_block":{"third_param": third_value}})
+    """
 
     path: Path
     specs: dict | None = None
@@ -424,12 +438,9 @@ class ConfigIconTaskSpecs:
 
 
 class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
-    # validation done here and not in ConfigNamelist so that we can still
-    # import ConfigIconTaskSpecs in core._tasks.IconTask. Hence the iteration
-    # over the namelists that could be avoided with a more raw pydantic design
     @field_validator("namelists", mode="before")
     @classmethod
-    def check_nml(cls, nml_list: list[Any]) -> ConfigNamelist:
+    def check_nml(cls, nml_list: list[Any]) -> dict[str, ConfigNamelist]:
         if nml_list is None:
             msg = "ICON tasks need namelists, got none"
             raise ValueError(msg)

--- a/src/sirocco/parsing/_yaml_data_models.py
+++ b/src/sirocco/parsing/_yaml_data_models.py
@@ -473,7 +473,6 @@ class DataType(enum.StrEnum):
     DIR = enum.auto()
 
 
-@dataclass
 @dataclass(kw_only=True)
 class ConfigBaseDataSpecs:
     type: DataType

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -8,7 +8,7 @@ from termcolor import colored
 from sirocco import core
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(kw_only=True)
 class PrettyPrinter:
     """
     Pretty print unrolled workflow graph elements in a reproducible and human readable format.


### PR DESCRIPTION
As advised by @DropD , we remove the necessity of ICON namelists being apparently optional for ICON tasks by using `@dataclass(kw_only=True)`. This is now used all over the code base.

Some doctests are also added  to `ConfigNamelist` and `ConfigIconTask`