### PR TITLE
Remove `pydantic-yaml` as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "numpy",
   "isoduration",
   "pydantic",
-  "pydantic-yaml",
+  "ruamel.yaml",
   "aiida-core>=2.5",
   "aiida-workgraph==0.4.10",
   "termcolor",


### PR DESCRIPTION
The amount of functionality we use of this library is extremely minimal. We replace it with the dependency `ruamel.yaml` that parses the yaml file into a python object. This is basically the code we use from the dependency https://github.com/NowanIlfideme/pydantic-yaml/blob/130569dabbe9843771bc6f7d52830e061238d61b/src/pydantic_yaml/_internals/v2.py#L217-L242

Furthermore, the library still uses pydantic API v1 for validating the pydantic model which is deprecated so we can replace it with pydantic v2. In addition this change gives us more flexibility as it separates the parsing of the yaml file and the validation through pydantic.

To have a similar utility function that can be used in the docstring tests we implement `validate_yaml_content`.

