### PR TITLE
Improve error handling in `ConfigWorkflow.from_config_file´

### DIFF
--- a/tests/unit_tests/parsing/test_yaml_data_models.py
+++ b/tests/unit_tests/parsing/test_yaml_data_models.py
@@ -53,3 +53,24 @@ def test_load_workflow_config(minimal_config_path):
     testee = models.ConfigWorkflow.from_config_file(str(minimal_config_path))
     assert testee.name == "minimal"
     assert testee.rootdir == minimal_config_path.parent
+
+
+def test_file_does_not_exist(tmp_path):
+    """Test that `ConfigWorkflow` fails if rootdir is None."""
+    nonexistant_file = str(tmp_path / "nonexistent_file")
+    with pytest.raises(FileNotFoundError, match=r".*nonexistent_file does not exist.*"):
+        _ = models.ConfigWorkflow.from_config_file(str(nonexistant_file))
+
+
+def test_from_config_file_is_not_file(tmp_path):
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    with pytest.raises(FileNotFoundError, match=r".*dir is not a file.*"):
+        _ = models.ConfigWorkflow.from_config_file(str(directory))
+
+
+def test_from_config_file_is_empty(tmp_path):
+    empty_file = tmp_path / "empty_file"
+    empty_file.write_text("")
+    with pytest.raises(ValueError, match=r".*empty_file is empty.*"):
+        _ = models.ConfigWorkflow.from_config_file(empty_file)


### PR DESCRIPTION
Handles the cases when the file specified does not exist, is not a file or is empty.