### PR TITLE
Rework command line specification

### DIFF
--- a/src/sirocco/core/__init__.py
+++ b/src/sirocco/core/__init__.py
@@ -1,5 +1,5 @@
 from ._tasks import IconTask, ShellTask
-from .graph_items import Cycle, Data, GraphItem, Task
+from .graph_items import AvailableData, Cycle, Data, GeneratedData, GraphItem, Task
 from .workflow import Workflow
 
-__all__ = ["Workflow", "GraphItem", "Data", "Task", "Cycle", "ShellTask", "IconTask"]
+__all__ = ["Workflow", "GraphItem", "Data", "AvailableData", "GeneratedData", "Task", "Cycle", "ShellTask", "IconTask"]

--- a/src/sirocco/core/_tasks/icon_task.py
+++ b/src/sirocco/core/_tasks/icon_task.py
@@ -60,12 +60,10 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
             }
         )
         self.core_namelists["icon_master.namelist"]["master_nml"]["lrestart"] = any(
-            # NOTE: in_data[0] contains the actual data node and in_data[1] the port name
-            in_data[1] == "restart"
-            for in_data in self.inputs
+            port == "restart" for _, port in self.inputs
         )
 
-    def dump_core_namelists(self, folder=None):
+    def dump_core_namelists(self, folder: str | Path | None = None):
         if folder is not None:
             folder = Path(folder)
             folder.mkdir(parents=True, exist_ok=True)

--- a/src/sirocco/core/_tasks/icon_task.py
+++ b/src/sirocco/core/_tasks/icon_task.py
@@ -59,9 +59,7 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
                 "experimentStopDate": self.cycle_point.stop_date.isoformat() + "Z",
             }
         )
-        self.core_namelists["icon_master.namelist"]["master_nml"]["lrestart"] = any(
-            port == "restart" for _, port in self.inputs
-        )
+        self.core_namelists["icon_master.namelist"]["master_nml"]["lrestart"] = bool(self.inputs["restart"])
 
     def dump_core_namelists(self, folder: str | Path | None = None):
         if folder is not None:

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from itertools import chain, product
-from typing import TYPE_CHECKING, Any, ClassVar, Self, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, TypeVar, cast
 
 from sirocco.parsing.target_cycle import DateList, LagList, NoTargetCycle
 from sirocco.parsing.yaml_data_models import (
@@ -65,10 +65,6 @@ class GeneratedData(Data):
     pass
 
 
-# contains the input data and its potential associated port
-BoundData: TypeAlias = tuple[Data, str | None]
-
-
 @dataclass(kw_only=True)
 class Task(ConfigBaseTaskSpecs, GraphItem):
     """Internal representation of a task node"""
@@ -76,7 +72,7 @@ class Task(ConfigBaseTaskSpecs, GraphItem):
     plugin_classes: ClassVar[dict[str, type[Self]]] = field(default={}, repr=False)
     color: ClassVar[Color] = field(default="light_red", repr=False)
 
-    inputs: list[BoundData] = field(default_factory=list)
+    inputs: dict[str, list[Data]] = field(default_factory=dict)
     outputs: list[Data] = field(default_factory=list)
     wait_on: list[Task] = field(default_factory=list)
     config_rootdir: Path
@@ -91,6 +87,9 @@ class Task(ConfigBaseTaskSpecs, GraphItem):
             raise ValueError(msg)
         Task.plugin_classes[cls.plugin] = cls
 
+    def input_data_nodes(self) -> Iterator[Data]:
+        yield from chain(*self.inputs.values())
+
     @classmethod
     def from_config(
         cls: type[Self],
@@ -101,11 +100,11 @@ class Task(ConfigBaseTaskSpecs, GraphItem):
         datastore: Store,
         graph_spec: ConfigCycleTask,
     ) -> Task:
-        inputs = [
-            (data_node, input_spec.port)
-            for input_spec in graph_spec.inputs
-            for data_node in datastore.iter_from_cycle_spec(input_spec, coordinates)
-        ]
+        inputs: dict[str, list[Data]] = {}
+        for input_spec in graph_spec.inputs:
+            if input_spec.port not in inputs:
+                inputs[input_spec.port] = []
+            inputs[input_spec.port].extend(datastore.iter_from_cycle_spec(input_spec, coordinates))
         outputs = [datastore[output_spec.name, coordinates] for output_spec in graph_spec.outputs]
         if (plugin_cls := Task.plugin_classes.get(type(config).plugin, None)) is None:
             msg = f"Plugin {type(config).plugin!r} is not supported."

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -46,17 +46,23 @@ class Data(ConfigBaseDataSpecs, GraphItem):
 
     color: ClassVar[Color] = field(default="light_blue", repr=False)
 
-    available: bool
-
     @classmethod
-    def from_config(cls, config: ConfigBaseData, coordinates: dict) -> Self:
-        return cls(
+    def from_config(cls, config: ConfigBaseData, coordinates: dict) -> AvailableData | GeneratedData:
+        data_class = AvailableData if isinstance(config, ConfigAvailableData) else GeneratedData
+        return data_class(
             name=config.name,
             type=config.type,
             src=config.src,
-            available=isinstance(config, ConfigAvailableData),
             coordinates=coordinates,
         )
+
+
+class AvailableData(Data):
+    pass
+
+
+class GeneratedData(Data):
+    pass
 
 
 # contains the input data and its potential associated port

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -161,7 +161,7 @@ class TargetNodesBaseModel(_NamedBaseModel):
 
 
 class ConfigCycleTaskInput(TargetNodesBaseModel):
-    port: str = "None"
+    port: str
 
 
 class ConfigCycleTaskWaitOn(TargetNodesBaseModel):

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -317,6 +317,7 @@ class ConfigShellTask(ConfigBaseTask, ConfigShellTaskSpecs):
         >>> my_task.walltime.tm_min
         1
     """
+
     env_source_files: list[str] = Field(default_factory=list)
 
     @field_validator("env_source_files", mode="before")
@@ -597,7 +598,9 @@ class ConfigWorkflow(BaseModel):
             ...     name="minimal",
             ...     rootdir=Path("/location/of/config/file"),
             ...     cycles=[ConfigCycle(minimal_cycle={"tasks": [ConfigCycleTask(task_a={})]})],
-            ...     tasks=[ConfigShellTask(task_a={"plugin": "shell", "command": "some_command"})],
+            ...     tasks=[
+            ...         ConfigShellTask(task_a={"plugin": "shell", "command": "some_command"})
+            ...     ],
             ...     data=ConfigData(
             ...         available=[
             ...             ConfigAvailableData(name="foo", type=DataType.FILE, src="foo.txt")

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -284,7 +284,9 @@ class ConfigShellTaskSpecs:
     env_source_files: list[str] = field(default_factory=list)
 
     def resolve_ports(self, input_labels: dict[str, list[str]]) -> str:
-        """returns a string corresponding to self.command with "{PORT::port_name}"
+        """Replace port placeholders in command string with provided input labels.
+
+        Returns a string corresponding to self.command with "{PORT::port_name}"
         placeholders replaced by the content provided in the input_labels dict.
         When multiple input nodes are linked to a single port (e.g. with
         parameterized data or if the `when` keyword specifies a list of lags or
@@ -309,6 +311,14 @@ class ConfigShellTaskSpecs:
             ...     {"positionals": ["input_1", "input_2"], "multi_arg": ["input_3", "input_4"]}
             ... )
             './my_script input_1 input_2 --multi_arg input_3,input_4'
+
+            >>> task_specs = ConfigShellTaskSpecs(
+            ...     command="./my_script --input {PORT[sep= --input ]::repeat_input}"
+            ... )
+            >>> task_specs.resolve_ports(
+            ...     {"repeat_input": ["input_1", "input_2", "input_3"]}
+            ... )
+            './my_script --input input_1 --input input_2 --input input_3'
         """
         cmd = self.command
         for port_match in self.port_pattern.finditer(cmd):

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -315,9 +315,7 @@ class ConfigShellTaskSpecs:
             >>> task_specs = ConfigShellTaskSpecs(
             ...     command="./my_script --input {PORT[sep= --input ]::repeat_input}"
             ... )
-            >>> task_specs.resolve_ports(
-            ...     {"repeat_input": ["input_1", "input_2", "input_3"]}
-            ... )
+            >>> task_specs.resolve_ports({"repeat_input": ["input_1", "input_2", "input_3"]})
             './my_script --input input_1 --input input_2 --input input_3'
         """
         cmd = self.command

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -317,8 +317,6 @@ class ConfigShellTask(ConfigBaseTask, ConfigShellTaskSpecs):
         >>> my_task.walltime.tm_min
         1
     """
-
-    command: str = ""
     env_source_files: list[str] = Field(default_factory=list)
 
     @field_validator("env_source_files", mode="before")
@@ -579,6 +577,7 @@ class ConfigWorkflow(BaseModel):
             ...     tasks:
             ...       - task_a:
             ...           plugin: shell
+            ...           command: "some_command"
             ...     data:
             ...       available:
             ...         - foo:
@@ -598,7 +597,7 @@ class ConfigWorkflow(BaseModel):
             ...     name="minimal",
             ...     rootdir=Path("/location/of/config/file"),
             ...     cycles=[ConfigCycle(minimal_cycle={"tasks": [ConfigCycleTask(task_a={})]})],
-            ...     tasks=[ConfigShellTask(task_a={"plugin": "shell"})],
+            ...     tasks=[ConfigShellTask(task_a={"plugin": "shell", "command": "some_command"})],
             ...     data=ConfigData(
             ...         available=[
             ...             ConfigAvailableData(name="foo", type=DataType.FILE, src="foo.txt")

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -311,17 +311,20 @@ class ConfigShellTaskSpecs:
             './my_script input_1 input_2 --multi_arg input_3,input_4'
         """
         cmd = self.command
-        for m in self.port_pattern.finditer(cmd):
-            if (port_name := m.group(2)) is None:
-                msg = f"Wrong port name specification: {m.group(0)}"
+        for port_match in self.port_pattern.finditer(cmd):
+            if (port_name := port_match.group(2)) is None:
+                msg = f"Wrong port specification: {port_match.group(0)}"
                 raise ValueError(msg)
-            if (sep := m.group(1)) is not None:
-                if (arg_sep := self.sep_pattern.match(sep).group(1)) is None:
+            if (sep := port_match.group(1)) is None:
+                arg_sep = " "
+            else:
+                if (sep_match := self.sep_pattern.match(sep)) is None:
                     msg = "Wrong separator specification: sep"
                     raise ValueError(msg)
-            else:
-                arg_sep = " "
-            cmd = cmd.replace(m.group(0), arg_sep.join(input_labels[port_name]))
+                if (arg_sep := sep_match.group(1)) is None:
+                    msg = "Wrong separator specification: sep"
+                    raise ValueError(msg)
+            cmd = cmd.replace(port_match.group(0), arg_sep.join(input_labels[port_name]))
         return cmd
 
 

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -283,7 +283,7 @@ class ConfigShellTaskSpecs:
     multi_arg_sep: str = " "
     env_source_files: list[str] = field(default_factory=list)
 
-    def replace_ports(self, input_labels: dict[str, list[str]]) -> str:
+    def resolve_ports(self, input_labels: dict[str, list[str]]) -> str:
         """returns a string corresponding to self.command with {PORT::...}
         placeholders replaced by the content provided in the input_labels dict"""
         cmd = self.command

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -298,8 +298,7 @@ class ConfigShellTaskSpecs:
             ...     command="./my_script {PORT::positionals} -l -c --verbose 2 --arg {PORT::my_arg}"
             ... )
             >>> task_specs.resolve_ports(
-            ...     {"positionals": ["input_1", "input_2"],
-            ...      "my_arg": ["input_3"]}
+            ...     {"positionals": ["input_1", "input_2"], "my_arg": ["input_3"]}
             ... )
             './my_script input_1 input_2 -l -c --verbose 2 --arg input_3'
 
@@ -307,15 +306,14 @@ class ConfigShellTaskSpecs:
             ...     command="./my_script {PORT::positionals} --multi_arg {PORT[sep=,]::multi_arg}"
             ... )
             >>> task_specs.resolve_ports(
-            ...     {"positionals": ["input_1", "input_2"],
-            ...      "multi_arg": ["input_3", "input_4"]}
+            ...     {"positionals": ["input_1", "input_2"], "multi_arg": ["input_3", "input_4"]}
             ... )
             './my_script input_1 input_2 --multi_arg input_3,input_4'
         """
         cmd = self.command
         for m in self.port_pattern.finditer(cmd):
             port_name = m.group(2)
-            if (sep := m.group(1)):
+            if sep := m.group(1):
                 if not (arg_sep := self.sep_pattern.match(sep).group(1)):
                     msg = "A separator should have been identified at that stage. Please contact a developper"
                     raise ValueError(msg)

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -284,13 +284,13 @@ class ConfigShellTaskSpecs:
     env_source_files: list[str] = field(default_factory=list)
 
     def resolve_ports(self, input_labels: dict[str, list[str]]) -> str:
-        """returns a string corresponding to self.command with "{PORT::...}"
+        """returns a string corresponding to self.command with "{PORT::port_name}"
         placeholders replaced by the content provided in the input_labels dict.
         When multiple input nodes are linked to a single port (e.g. with
         parameterized data or if the `when` keyword specifies a list of lags or
         dates), the provided input labels are inserted with a separator
         defaulting to a " ". Specifying an alternative separator, e.g. a comma,
-        is done via "{PORT[sep=,]::...}"
+        is done via "{PORT[sep=,]::port_name}"
 
         Examples:
 
@@ -312,10 +312,12 @@ class ConfigShellTaskSpecs:
         """
         cmd = self.command
         for m in self.port_pattern.finditer(cmd):
-            port_name = m.group(2)
-            if sep := m.group(1):
-                if not (arg_sep := self.sep_pattern.match(sep).group(1)):
-                    msg = "A separator should have been identified at that stage. Please contact a developper"
+            if (port_name := m.group(2)) is None:
+                msg = f"Wrong port name specification: {m.group(0)}"
+                raise ValueError(msg)
+            if (sep := m.group(1)) is not None:
+                if (arg_sep := self.sep_pattern.match(sep).group(1)) is None:
+                    msg = "Wrong separator specification: sep"
                     raise ValueError(msg)
             else:
                 arg_sep = " "

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -132,7 +132,7 @@ class PrettyPrinter:
             sections.append(
                 self.as_block(
                     "input",
-                    "\n".join(self.as_item(self.format_basic(inp[0])) for inp in obj.inputs),
+                    "\n".join(self.as_item(self.format_basic(inp)) for inp in obj.input_data_nodes()),
                 )
             )
         if obj.outputs:

--- a/src/sirocco/vizgraph.py
+++ b/src/sirocco/vizgraph.py
@@ -56,8 +56,7 @@ class VizGraph:
                 self.agraph.add_node(
                     task_node, label=task_node.name, tooltip=self.tooltip(task_node), **self.task_node_kw
                 )
-                # NOTE: _ stands for the unsued port name
-                for data_node, _ in task_node.inputs:
+                for data_node in task_node.input_data_nodes():
                     self.agraph.add_edge(data_node, task_node, **self.io_edge_kw)
                 for data_node in task_node.outputs:
                     self.agraph.add_edge(task_node, data_node, **self.io_edge_kw)

--- a/src/sirocco/vizgraph.py
+++ b/src/sirocco/vizgraph.py
@@ -10,7 +10,7 @@ from pygraphviz import AGraph
 
 if TYPE_CHECKING:
     from sirocco.core.graph_items import Store
-from sirocco.core import Workflow
+from sirocco import core
 
 
 def hsv_to_hex(h: float, s: float, v: float) -> str:
@@ -43,7 +43,7 @@ class VizGraph:
         self.name = name
         self.agraph = AGraph(name=name, fontname="Fira Sans", newrank=True)
         for data_node in data:
-            gv_kw = self.data_av_node_kw if data_node.available else self.data_gen_node_kw
+            gv_kw = self.data_av_node_kw if isinstance(data_node, core.AvailableData) else self.data_gen_node_kw
             self.agraph.add_node(data_node, tooltip=self.tooltip(data_node), label=data_node.name, **gv_kw)
 
         k = 1
@@ -110,9 +110,9 @@ class VizGraph:
         svg.write(file_path)
 
     @classmethod
-    def from_core_workflow(cls, workflow: Workflow):
+    def from_core_workflow(cls, workflow: core.Workflow):
         return cls(workflow.name, workflow.cycles, workflow.data)
 
     @classmethod
     def from_config_file(cls, config_path: str):
-        return cls.from_core_workflow(Workflow.from_config_file(config_path))
+        return cls.from_core_workflow(core.Workflow.from_config_file(config_path))

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -213,6 +213,7 @@ class AiidaWorkGraph:
             #           - relative path to the task working directory (./my_script.sh)
             #           - something added to $PATH through environment activation (cdo)
             #        So the full path to the command can only be resolved at runtime.
+            #        See issue https://github.com/C2SM/Sirocco/issues/127
             if cmd_path.is_absolute():
                 command = str(cmd_path)
             else:

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -93,7 +93,7 @@ class AiidaWorkGraph:
             except ValueError as exception:
                 msg = f"Raised error when validating task name '{task.name}': {exception.args[0]}"
                 raise ValueError(msg) from exception
-            for input_, _ in task.inputs:
+            for input_ in task.input_data_nodes():
                 try:
                     aiida.common.validate_link_label(input_.name)
                 except ValueError as exception:
@@ -123,31 +123,42 @@ class AiidaWorkGraph:
             label = label.replace(invalid_char, "_")
         return label
 
-    @staticmethod
-    def get_aiida_label_from_graph_item(obj: core.GraphItem) -> str:
+    @classmethod
+    def get_aiida_label_from_graph_item(cls, obj: core.GraphItem) -> str:
         """Returns a unique AiiDA label for the given graph item.
 
         The graph item object is uniquely determined by its name and its coordinates. There is the possibility that
         through the replacement of invalid chars in the coordinates duplication can happen but it is unlikely.
         """
-        return AiidaWorkGraph.replace_invalid_chars_in_label(
+        return cls.replace_invalid_chars_in_label(
             f"{obj.name}" + "__".join(f"_{key}_{value}" for key, value in obj.coordinates.items())
         )
 
-    def workgraph_data_node_from_core(self, core_available_data: core.AvailableData) -> WorkgraphDataNode:
-        return self._aiida_data_nodes[AiidaWorkGraph.get_aiida_label_from_graph_item(core_available_data)]
+    @staticmethod
+    def split_cmd_arg(command_line: str) -> tuple[str, str]:
+        split = command_line.split(sep=" ", maxsplit=1)
+        if len(split) == 1:
+            return command_line, ""
+        return split[0], split[1]
 
-    def workgraph_socket_node_from_core(self, core_generated_data: core.GeneratedData) -> TaskSocket:
-        return self._aiida_socket_nodes[AiidaWorkGraph.get_aiida_label_from_graph_item(core_generated_data)]
+    @classmethod
+    def label_placeholder(cls, data: core.Data) -> str:
+        return f"{{{cls.get_aiida_label_from_graph_item(data)}}}"
 
-    def workgraph_task_node_from_core(self, core_task: core.Task) -> aiida_workgraph.Task:
-        return self._aiida_task_nodes[AiidaWorkGraph.get_aiida_label_from_graph_item(core_task)]
+    def data_from_core(self, core_available_data: core.AvailableData) -> WorkgraphDataNode:
+        return self._aiida_data_nodes[self.get_aiida_label_from_graph_item(core_available_data)]
+
+    def socket_from_core(self, core_generated_data: core.GeneratedData) -> TaskSocket:
+        return self._aiida_socket_nodes[self.get_aiida_label_from_graph_item(core_generated_data)]
+
+    def task_from_core(self, core_task: core.Task) -> aiida_workgraph.Task:
+        return self._aiida_task_nodes[self.get_aiida_label_from_graph_item(core_task)]
 
     def _add_aiida_input_data_node(self, data: core.Data):
         """
         Create an `aiida.orm.Data` instance from the provided graph item.
         """
-        label = AiidaWorkGraph.get_aiida_label_from_graph_item(data)
+        label = self.get_aiida_label_from_graph_item(data)
         data_path = Path(data.src)
         data_full_path = data.src if data_path.is_absolute() else self._core_workflow.config_rootdir / data_path
 
@@ -179,23 +190,36 @@ class AiidaWorkGraph:
         for task in self._core_workflow.tasks:
             self._link_wait_on_to_task(task)
 
+        # FIXME: Nothing ensures that the input data nodes are all created
+        #        before linking them to the task. It currently depends on the
+        #        order in which tasks were specified in the config file which
+        #        should have no influence here.
         for task in self._core_workflow.tasks:
             for output in task.outputs:
                 self._link_output_nodes_to_task(task, output)
-            for input_, _ in task.inputs:
+            for input_ in task.input_data_nodes():
                 self._link_input_nodes_to_task(task, input_)
             self._link_arguments_to_task(task)
 
     def _create_task_node(self, task: core.Task):
-        label = AiidaWorkGraph.get_aiida_label_from_graph_item(task)
+        label = self.get_aiida_label_from_graph_item(task)
         if isinstance(task, core.ShellTask):
-            command_path = Path(task.command)
-            command_full_path = task.command if command_path.is_absolute() else task.config_rootdir / command_path
-            command = str(command_full_path)
+            # Split command line between command and arguments (this is required by aiida internals)
+            command, _ = self.split_cmd_arg(task.command)
+            command = Path(command)
+            # FIXME: task.config_rootdir shouldn't be used here
+            if command.is_absolute():
+                command = str(command)
+            else:
+                if task.src is None:
+                    msg = "src must be specified when command path is relative"
+                    raise ValueError(msg)
+                command = str((task.config_rootdir / task.src).parent / command)
 
             # metadata
             metadata: dict[str, Any] = {}
             ## Source file
+            # FIXME: Same as above
             env_source_paths = [
                 env_source_path
                 if (env_source_path := Path(env_source_file)).is_absolute()
@@ -220,7 +244,7 @@ class AiidaWorkGraph:
                 "ShellJob",
                 name=label,
                 command=command,
-                arguments=[],
+                arguments="",
                 outputs=[],
                 metadata=metadata,
             )
@@ -235,12 +259,12 @@ class AiidaWorkGraph:
             raise NotImplementedError(exc)
 
     def _link_wait_on_to_task(self, task: core.Task):
-        self.workgraph_task_node_from_core(task).wait = [self.workgraph_task_node_from_core(wt) for wt in task.wait_on]
+        self.task_from_core(task).wait = [self.task_from_core(wt) for wt in task.wait_on]
 
     def _link_input_nodes_to_task(self, task: core.Task, input_: core.Data):
         """Links the input to the workgraph task."""
-        workgraph_task = self.workgraph_task_node_from_core(task)
-        input_label = AiidaWorkGraph.get_aiida_label_from_graph_item(input_)
+        workgraph_task = self.task_from_core(task)
+        input_label = self.get_aiida_label_from_graph_item(input_)
         workgraph_task.add_input("workgraph.any", f"nodes.{input_label}")
 
         # resolve data
@@ -248,22 +272,21 @@ class AiidaWorkGraph:
             if not hasattr(workgraph_task.inputs.nodes, f"{input_label}"):
                 msg = f"Socket {input_label!r} was not found in workgraph. Please contact a developer."
                 raise ValueError(msg)
-            socket = getattr(workgraph_task.inputs.nodes, f"{input_label}")
-            socket.value = self.workgraph_data_node_from_core(input_)
+            getattr(workgraph_task.inputs.nodes, f"{input_label}").value = self.data_from_core(input_)
         elif isinstance(input_, core.GeneratedData):
             self._workgraph.add_link(
-                self.workgraph_socket_node_from_core(input_), workgraph_task.inputs[f"nodes.{input_label}"]
+                self.socket_from_core(input_), workgraph_task.inputs[f"nodes.{input_label}"]
             )
         else:
             raise TypeError
 
     def _link_arguments_to_task(self, task: core.Task):
-        """Links the arguments to the workgraph task.
+        """replace port placeholders by aiida label placeholders"""
 
-        Parses `cli_arguments` of the graph item task and links all arguments to the task node. It only adds arguments
-        corresponding to inputs if they are contained in the task.
-        """
-        workgraph_task = self.workgraph_task_node_from_core(task)
+        if not isinstance(task, core.ShellTask):
+            raise TypeError
+
+        workgraph_task = self.task_from_core(task)
         if (workgraph_task_arguments := workgraph_task.inputs.arguments) is None:
             msg = (
                 f"Workgraph task {workgraph_task.name!r} did not initialize arguments nodes in the workgraph "
@@ -271,37 +294,15 @@ class AiidaWorkGraph:
             )
             raise ValueError(msg)
 
-        name_to_input_map = {input_.name: input_ for input_, _ in task.inputs}
-        # we track the linked input arguments, to ensure that all linked input nodes got linked arguments
-        linked_input_args = []
-        if not isinstance(task, core.ShellTask):
-            raise TypeError
-        for arg in task.cli_arguments:
-            if arg.references_data_item:
-                # We only add an input argument to the args if it has been added to the nodes
-                # This ensures that inputs and their arguments are only added
-                # when the time conditions are fulfilled
-                if (input_ := name_to_input_map.get(arg.name)) is not None:
-                    input_label = AiidaWorkGraph.get_aiida_label_from_graph_item(input_)
-
-                    if arg.cli_option_of_data_item is not None:
-                        workgraph_task_arguments.value.append(f"{arg.cli_option_of_data_item}")
-                    workgraph_task_arguments.value.append(f"{{{input_label}}}")
-                    linked_input_args.append(input_.name)
-            else:
-                workgraph_task_arguments.value.append(f"{arg.name}")
-        # Adding remaining input nodes as positional arguments
-        for input_name in name_to_input_map:
-            if input_name not in linked_input_args:
-                input_ = name_to_input_map[input_name]
-                input_label = AiidaWorkGraph.get_aiida_label_from_graph_item(input_)
-                workgraph_task_arguments.value.append(f"{{{input_label}}}")
+        input_labels = {port: list(map(self.label_placeholder, task.inputs[port])) for port in task.inputs}
+        _, arguments = self.split_cmd_arg(task.replace_ports(input_labels))
+        workgraph_task_arguments.value = arguments
 
     def _link_output_nodes_to_task(self, task: core.Task, output: core.Data):
         """Links the output to the workgraph task."""
 
-        workgraph_task = self._aiida_task_nodes[AiidaWorkGraph.get_aiida_label_from_graph_item(task)]
-        output_label = AiidaWorkGraph.get_aiida_label_from_graph_item(output)
+        workgraph_task = self.task_from_core(task)
+        output_label = self.get_aiida_label_from_graph_item(output)
         output_socket = workgraph_task.add_output("workgraph.any", output.src)
         self._aiida_socket_nodes[output_label] = output_socket
 

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -298,7 +298,7 @@ class AiidaWorkGraph:
             raise ValueError(msg)
 
         input_labels = {port: list(map(self.label_placeholder, task.inputs[port])) for port in task.inputs}
-        _, arguments = self.split_cmd_arg(task.replace_ports(input_labels))
+        _, arguments = self.split_cmd_arg(task.resolve_ports(input_labels))
         workgraph_task_arguments.value = arguments
 
     def _link_output_nodes_to_task(self, task: core.Task, output: core.Data):

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -190,10 +190,6 @@ class AiidaWorkGraph:
         for task in self._core_workflow.tasks:
             self._link_wait_on_to_task(task)
 
-        # FIXME: Nothing ensures that the input data nodes are all created
-        #        before linking them to the task. It currently depends on the
-        #        order in which tasks were specified in the config file which
-        #        should have no influence here.
         for task in self._core_workflow.tasks:
             for output in task.outputs:
                 self._link_output_nodes_to_task(task, output)
@@ -207,13 +203,7 @@ class AiidaWorkGraph:
             # Split command line between command and arguments (this is required by aiida internals)
             cmd, _ = self.split_cmd_arg(task.command)
             cmd_path = Path(cmd)
-            # FIXME: task.config_rootdir shouldn't be used here. The final behavior of Sirocco should be:
-            #        1- src is copied to the task working directory on the computer
-            #        2- If the command is gven with a relative path, it can target any executable in $PATH, e.g.:
-            #           - relative path to the task working directory (./my_script.sh)
-            #           - something added to $PATH through environment activation (cdo)
-            #        So the full path to the command can only be resolved at runtime.
-            #        See issue https://github.com/C2SM/Sirocco/issues/127
+            # FIXME: https://github.com/C2SM/Sirocco/issues/127
             if cmd_path.is_absolute():
                 command = str(cmd_path)
             else:
@@ -225,7 +215,6 @@ class AiidaWorkGraph:
             # metadata
             metadata: dict[str, Any] = {}
             ## Source file
-            # FIXME: Same as above
             env_source_paths = [
                 env_source_path
                 if (env_source_path := Path(env_source_file)).is_absolute()

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -274,9 +274,7 @@ class AiidaWorkGraph:
                 raise ValueError(msg)
             getattr(workgraph_task.inputs.nodes, f"{input_label}").value = self.data_from_core(input_)
         elif isinstance(input_, core.GeneratedData):
-            self._workgraph.add_link(
-                self.socket_from_core(input_), workgraph_task.inputs[f"nodes.{input_label}"]
-            )
+            self._workgraph.add_link(self.socket_from_core(input_), workgraph_task.inputs[f"nodes.{input_label}"])
         else:
             raise TypeError
 

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -205,16 +205,16 @@ class AiidaWorkGraph:
         label = self.get_aiida_label_from_graph_item(task)
         if isinstance(task, core.ShellTask):
             # Split command line between command and arguments (this is required by aiida internals)
-            command, _ = self.split_cmd_arg(task.command)
-            command = Path(command)
+            cmd, _ = self.split_cmd_arg(task.command)
+            cmd_path = Path(cmd)
             # FIXME: task.config_rootdir shouldn't be used here
-            if command.is_absolute():
-                command = str(command)
+            if cmd_path.is_absolute():
+                command = str(cmd_path)
             else:
                 if task.src is None:
                     msg = "src must be specified when command path is relative"
                     raise ValueError(msg)
-                command = str((task.config_rootdir / task.src).parent / command)
+                command = str((task.config_rootdir / task.src).parent / cmd_path)
 
             # metadata
             metadata: dict[str, Any] = {}

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -284,7 +284,7 @@ class AiidaWorkGraph:
             raise TypeError
 
     def _link_inputs_to_ports(self, task: core.Task):
-        """replace port placeholders by aiida label placeholders"""
+        """Set shell task arguments by replacing port placeholders with aiida labels"""
 
         if not isinstance(task, core.ShellTask):
             raise TypeError

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -5,7 +5,9 @@ cycles:
   - init:
       tasks:
         - extpar:
-            inputs: [obs_data]
+            inputs:
+              - obs_data:
+                  port: obs
             outputs: [extpar_file]
   - icon_bimonthly:
       cycling:
@@ -14,7 +16,13 @@ cycles:
         period: 'P2M'
       tasks:
         - preproc:
-            inputs: [grid_file, extpar_file, ERA5]
+            inputs:
+              - grid_file:
+                  port: grid
+              - extpar_file:
+                  port: extpar
+              - ERA5:
+                  port: era
             outputs: [icon_input]
             wait_on:
               - icon:
@@ -24,7 +32,8 @@ cycles:
                     lag: '-P4M'
         - icon:
             inputs:
-              - grid_file
+              - grid_file:
+                  port: grid
               - icon_input
               - icon_restart:
                   when:
@@ -37,7 +46,13 @@ cycles:
             inputs: [stream_1]
             outputs: [postout_1]
         - store_and_clean_1:
-            inputs: [postout_1, stream_1, icon_input]
+            inputs:
+              - postout_1:
+                  port: postout
+              - stream_1:
+                  port: streams
+              - icon_input:
+                  port: icon_input
             outputs: [stored_data_1]
   - yearly:
       cycling:
@@ -50,13 +65,16 @@ cycles:
               - stream_2:
                   target_cycle:
                     lag: ['P0M', 'P2M', 'P4M', 'P6M', 'P8M', 'P10M']
+                  port: streams
             outputs: [postout_2]
         - store_and_clean_2:
             inputs:
-              - postout_2
+              - postout_2:
+                  port: archive
               - stream_2:
                   target_cycle:
                     lag: ['P0M', 'P2M', 'P4M', 'P6M', 'P8M', 'P10M']
+                  port: clean
             outputs:
               - stored_data_2
 # Each task and piece of data (input and output of tasks) used to
@@ -68,8 +86,8 @@ tasks:
       account: g110
   - extpar:
       plugin: shell  # no extpar plugin available yet
-      command: scripts/extpar
-      cli_arguments: "--verbose {--input obs_data}"
+      src: scripts/extpar
+      command: "extpar --verbose --input {PORT::obs}"
       uenv:
         squashfs: path/to/squashfs
         mount_point: runtime/mount/point
@@ -77,8 +95,8 @@ tasks:
       walltime: 00:02:00
   - preproc:
       plugin: shell
-      command: scripts/cleanup.sh
-      cli_arguments: "{-p extpar_file} {-e ERA5} {grid_file}"
+      src: scripts/cleanup.sh
+      command: "cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}"
       env_source_files: data/dummy_source_file.sh
       nodes: 4
       walltime: 00:02:00
@@ -101,8 +119,8 @@ tasks:
         mount_point: runtime/mount/point
   - postproc_1:
       plugin: shell
-      command: scripts/main_script_ocn.sh
-      cli_arguments: "{--input stream_1}"
+      src: scripts/main_script_ocn.sh
+      command: "main_script_ocn.sh {PORT::None}"
       nodes: 2
       walltime: 00:05:00
       uenv:
@@ -110,24 +128,24 @@ tasks:
         mount_point: runtime/mount/point
   - postproc_2:
       plugin: shell
-      command: scripts/main_script_atm.sh
-      cli_arguments: "{--input stream_2}"
+      src: scripts/main_script_atm.sh
+      command: "main_script_atm.sh --input {PORT::streams}"
+      multi_arg_sep: ","
       nodes: 2
       walltime: 00:05:00
-      src: path/to/src/dir
       uenv:
         squashfs: path/to/squashfs
         mount_point: runtime/mount/point
   - store_and_clean_1:
       plugin: shell
-      command: scripts/post_clean.sh
-      cli_arguments: "{--input postout_1} {--stream stream_1} {--icon_input icon_input}"
+      src: scripts/post_clean.sh
+      command: "post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}"
       nodes: 1
       walltime: 00:01:00
   - store_and_clean_2:
       plugin: shell
-      command: scripts/post_clean.sh
-      cli_arguments: "{--input postout_2}"
+      src: scripts/post_clean.sh
+      command: "post_clean.sh --archive {PORT::archive} --clean {PORT::clean}"
       nodes: 1
       walltime: 00:01:00
 data:

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -34,7 +34,8 @@ cycles:
             inputs:
               - grid_file:
                   port: grid
-              - icon_input
+              - icon_input:
+                  port: lbc
               - icon_restart:
                   when:
                     after: *root_start_date
@@ -43,7 +44,9 @@ cycles:
                   port: restart
             outputs: [stream_1, stream_2, icon_restart]
         - postproc_1:
-            inputs: [stream_1]
+            inputs:
+              - stream_1:
+                  port: None
             outputs: [postout_1]
         - store_and_clean_1:
             inputs:

--- a/tests/cases/large/data/config.txt
+++ b/tests/cases/large/data/config.txt
@@ -15,7 +15,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/extpar'
             command: 'extpar --verbose --input {PORT::obs}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-01-01 00:00:00]:
       tasks:
@@ -35,7 +34,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-01-01 00:00:00]:
             input:
@@ -68,7 +66,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-01-01 00:00:00]:
             input:
@@ -85,7 +82,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-03-01 00:00:00]:
       tasks:
@@ -105,7 +101,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-03-01 00:00:00]:
             input:
@@ -139,7 +134,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-03-01 00:00:00]:
             input:
@@ -156,7 +150,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-05-01 00:00:00]:
       tasks:
@@ -178,7 +171,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-05-01 00:00:00]:
             input:
@@ -212,7 +204,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-05-01 00:00:00]:
             input:
@@ -229,7 +220,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-07-01 00:00:00]:
       tasks:
@@ -251,7 +241,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-07-01 00:00:00]:
             input:
@@ -285,7 +274,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-07-01 00:00:00]:
             input:
@@ -302,7 +290,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-09-01 00:00:00]:
       tasks:
@@ -324,7 +311,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-09-01 00:00:00]:
             input:
@@ -358,7 +344,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-09-01 00:00:00]:
             input:
@@ -375,7 +360,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-11-01 00:00:00]:
       tasks:
@@ -397,7 +381,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-11-01 00:00:00]:
             input:
@@ -431,7 +414,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-11-01 00:00:00]:
             input:
@@ -448,7 +430,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-01-01 00:00:00]:
       tasks:
@@ -470,7 +451,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-01-01 00:00:00]:
             input:
@@ -504,7 +484,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-01-01 00:00:00]:
             input:
@@ -521,7 +500,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-03-01 00:00:00]:
       tasks:
@@ -543,7 +521,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-03-01 00:00:00]:
             input:
@@ -577,7 +554,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-03-01 00:00:00]:
             input:
@@ -594,7 +570,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-05-01 00:00:00]:
       tasks:
@@ -616,7 +591,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-05-01 00:00:00]:
             input:
@@ -650,7 +624,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-05-01 00:00:00]:
             input:
@@ -667,7 +640,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-07-01 00:00:00]:
       tasks:
@@ -689,7 +661,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-07-01 00:00:00]:
             input:
@@ -723,7 +694,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-07-01 00:00:00]:
             input:
@@ -740,7 +710,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-09-01 00:00:00]:
       tasks:
@@ -762,7 +731,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-09-01 00:00:00]:
             input:
@@ -796,7 +764,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-09-01 00:00:00]:
             input:
@@ -813,7 +780,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-11-01 00:00:00]:
       tasks:
@@ -835,7 +801,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.sh'
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-11-01 00:00:00]:
             input:
@@ -869,7 +834,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_ocn.sh'
             command: 'main_script_ocn.sh {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-11-01 00:00:00]:
             input:
@@ -886,7 +850,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
-            multi arg sep: ' '
             env source files: []
   - yearly [date: 2025-01-01 00:00:00]:
       tasks:
@@ -909,7 +872,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_atm.sh'
             command: 'main_script_atm.sh --input {PORT::streams}'
-            multi arg sep: ','
             env source files: []
         - store_and_clean_2 [date: 2025-01-01 00:00:00]:
             input:
@@ -930,7 +892,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh --archive {PORT::archive} --clean {PORT::clean}'
-            multi arg sep: ' '
             env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
@@ -953,7 +914,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/main_script_atm.sh'
             command: 'main_script_atm.sh --input {PORT::streams}'
-            multi arg sep: ','
             env source files: []
         - store_and_clean_2 [date: 2026-01-01 00:00:00]:
             input:
@@ -974,5 +934,4 @@ cycles:
             plugin: 'shell'
             src: 'scripts/post_clean.sh'
             command: 'post_clean.sh --archive {PORT::archive} --clean {PORT::clean}'
-            multi arg sep: ' '
             env source files: []

--- a/tests/cases/large/data/config.txt
+++ b/tests/cases/large/data/config.txt
@@ -13,8 +13,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: []
             plugin: 'shell'
-            command: 'scripts/extpar'
-            cli arguments: [ShellCliArgument(name='--verbose', references_data_item=False, cli_option_of_data_item=None), ShellCliArgument(name='obs_data', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/extpar'
+            command: 'extpar --verbose --input {PORT::obs}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-01-01 00:00:00]:
       tasks:
@@ -32,8 +33,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-01-01 00:00:00]:
             input:
@@ -64,8 +66,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-01-01 00:00:00]:
             input:
@@ -80,8 +83,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-03-01 00:00:00]:
       tasks:
@@ -99,8 +103,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-03-01 00:00:00]:
             input:
@@ -132,8 +137,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-03-01 00:00:00]:
             input:
@@ -148,8 +154,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-05-01 00:00:00]:
       tasks:
@@ -169,8 +176,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-05-01 00:00:00]:
             input:
@@ -202,8 +210,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-05-01 00:00:00]:
             input:
@@ -218,8 +227,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-07-01 00:00:00]:
       tasks:
@@ -239,8 +249,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-07-01 00:00:00]:
             input:
@@ -272,8 +283,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-07-01 00:00:00]:
             input:
@@ -288,8 +300,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-09-01 00:00:00]:
       tasks:
@@ -309,8 +322,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-09-01 00:00:00]:
             input:
@@ -342,8 +356,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-09-01 00:00:00]:
             input:
@@ -358,8 +373,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2025-11-01 00:00:00]:
       tasks:
@@ -379,8 +395,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-11-01 00:00:00]:
             input:
@@ -412,8 +429,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2025-11-01 00:00:00]:
             input:
@@ -428,8 +446,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-01-01 00:00:00]:
       tasks:
@@ -449,8 +468,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-01-01 00:00:00]:
             input:
@@ -482,8 +502,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-01-01 00:00:00]:
             input:
@@ -498,8 +519,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-03-01 00:00:00]:
       tasks:
@@ -519,8 +541,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-03-01 00:00:00]:
             input:
@@ -552,8 +575,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-03-01 00:00:00]:
             input:
@@ -568,8 +592,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-05-01 00:00:00]:
       tasks:
@@ -589,8 +614,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-05-01 00:00:00]:
             input:
@@ -622,8 +648,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-05-01 00:00:00]:
             input:
@@ -638,8 +665,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-07-01 00:00:00]:
       tasks:
@@ -659,8 +687,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-07-01 00:00:00]:
             input:
@@ -692,8 +721,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-07-01 00:00:00]:
             input:
@@ -708,8 +738,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-09-01 00:00:00]:
       tasks:
@@ -729,8 +760,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-09-01 00:00:00]:
             input:
@@ -762,8 +794,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-09-01 00:00:00]:
             input:
@@ -778,8 +811,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - icon_bimonthly [date: 2026-11-01 00:00:00]:
       tasks:
@@ -799,8 +833,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/cleanup.sh'
-            cli arguments: [ShellCliArgument(name='extpar_file', references_data_item=True, cli_option_of_data_item='-p'), ShellCliArgument(name='ERA5', references_data_item=True, cli_option_of_data_item='-e'), ShellCliArgument(name='grid_file', references_data_item=True, cli_option_of_data_item=None)]
+            src: 'scripts/cleanup.sh'
+            command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-11-01 00:00:00]:
             input:
@@ -832,8 +867,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_ocn.sh'
-            cli arguments: [ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_ocn.sh'
+            command: 'main_script_ocn.sh {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - store_and_clean_1 [date: 2026-11-01 00:00:00]:
             input:
@@ -848,8 +884,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_1', references_data_item=True, cli_option_of_data_item='--input'), ShellCliArgument(name='stream_1', references_data_item=True, cli_option_of_data_item='--stream'), ShellCliArgument(name='icon_input', references_data_item=True, cli_option_of_data_item='--icon_input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
+            multi arg sep: ' '
             env source files: []
   - yearly [date: 2025-01-01 00:00:00]:
       tasks:
@@ -870,10 +907,10 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_atm.sh'
-            cli arguments: [ShellCliArgument(name='stream_2', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_atm.sh'
+            command: 'main_script_atm.sh --input {PORT::streams}'
+            multi arg sep: ','
             env source files: []
-            src: 'path/to/src/dir'
         - store_and_clean_2 [date: 2025-01-01 00:00:00]:
             input:
               - postout_2 [date: 2025-01-01 00:00:00]
@@ -891,8 +928,9 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_2', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh --archive {PORT::archive} --clean {PORT::clean}'
+            multi arg sep: ' '
             env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
@@ -913,10 +951,10 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/main_script_atm.sh'
-            cli arguments: [ShellCliArgument(name='stream_2', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/main_script_atm.sh'
+            command: 'main_script_atm.sh --input {PORT::streams}'
+            multi arg sep: ','
             env source files: []
-            src: 'path/to/src/dir'
         - store_and_clean_2 [date: 2026-01-01 00:00:00]:
             input:
               - postout_2 [date: 2026-01-01 00:00:00]
@@ -934,6 +972,7 @@ cycles:
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/post_clean.sh'
-            cli arguments: [ShellCliArgument(name='postout_2', references_data_item=True, cli_option_of_data_item='--input')]
+            src: 'scripts/post_clean.sh'
+            command: 'post_clean.sh --archive {PORT::archive} --clean {PORT::clean}'
+            multi arg sep: ' '
             env source files: []

--- a/tests/cases/parameters/config/config.yml
+++ b/tests/cases/parameters/config/config.yml
@@ -14,6 +14,7 @@ cycles:
               - initial_conditions:
                   when:
                     at: *root_start_date
+                  port: init
               - icon_restart:
                   when:
                     after: *root_start_date
@@ -22,7 +23,9 @@ cycles:
                   parameters:
                     foo: single
                     bar: single
-              - forcing
+                  port: restart
+              - forcing:
+                  port: forcing
             outputs: [icon_output, icon_restart]
         - statistics_foo:
             inputs:
@@ -49,19 +52,22 @@ cycles:
 tasks:
   - icon:
       plugin: shell
-      command: scripts/icon.py
-      cli_arguments: "{--restart icon_restart} {--init initial_conditions} {--forcing forcing}"
+      src: scripts/icon.py
+      command: "icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}"
       parameters: [foo, bar]
   - statistics_foo:
       plugin: shell
-      command: scripts/statistics.py
+      src: scripts/statistics.py
+      command: "statistics.py {PORT::None}"
       parameters: [bar]
   - statistics_foo_bar:
       plugin: shell
-      command: scripts/statistics.py
+      src: scripts/statistics.py
+      command: "statistics.py {PORT::None}"
   - merge:
       plugin: shell
-      command: scripts/merge.py
+      src: scripts/merge.py
+      command: "merge.py {PORT::None}"
 
 data:
   available:

--- a/tests/cases/parameters/config/config.yml
+++ b/tests/cases/parameters/config/config.yml
@@ -32,9 +32,12 @@ cycles:
               - icon_output:
                   parameters:
                     bar: single
+                  port: None
             outputs: [analysis_foo]
         - statistics_foo_bar:
-            inputs: [analysis_foo]
+            inputs:
+              - analysis_foo:
+                  port: None
             outputs: [analysis_foo_bar]
   - yearly:
       cycling:
@@ -47,6 +50,7 @@ cycles:
               - analysis_foo_bar:
                   target_cycle:
                     lag: ['P0M', 'P6M']
+                  port: None
             outputs: [yearly_analysis]
 
 tasks:

--- a/tests/cases/parameters/data/config.txt
+++ b/tests/cases/parameters/data/config.txt
@@ -12,8 +12,9 @@ cycles:
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2026-01-01 00:00:00]:
             input:
@@ -26,8 +27,9 @@ cycles:
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2026-01-01 00:00:00]:
             input:
@@ -39,8 +41,9 @@ cycles:
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2026-01-01 00:00:00]:
             input:
@@ -51,8 +54,9 @@ cycles:
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
   - bimonthly_tasks [date: 2026-07-01 00:00:00]:
       tasks:
@@ -67,8 +71,9 @@ cycles:
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2026-07-01 00:00:00]:
             input:
@@ -81,8 +86,9 @@ cycles:
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2026-07-01 00:00:00]:
             input:
@@ -94,8 +100,9 @@ cycles:
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2026-07-01 00:00:00]:
             input:
@@ -106,8 +113,9 @@ cycles:
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
   - bimonthly_tasks [date: 2027-01-01 00:00:00]:
       tasks:
@@ -122,8 +130,9 @@ cycles:
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2027-01-01 00:00:00]:
             input:
@@ -136,8 +145,9 @@ cycles:
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2027-01-01 00:00:00]:
             input:
@@ -149,8 +159,9 @@ cycles:
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2027-01-01 00:00:00]:
             input:
@@ -161,8 +172,9 @@ cycles:
             coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
   - bimonthly_tasks [date: 2027-07-01 00:00:00]:
       tasks:
@@ -177,8 +189,9 @@ cycles:
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2027-07-01 00:00:00]:
             input:
@@ -191,8 +204,9 @@ cycles:
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init'), ShellCliArgument(name='forcing', references_data_item=True, cli_option_of_data_item='--forcing')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2027-07-01 00:00:00]:
             input:
@@ -204,8 +218,9 @@ cycles:
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2027-07-01 00:00:00]:
             input:
@@ -216,8 +231,9 @@ cycles:
             coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0)}
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/statistics.py'
-            cli arguments: []
+            src: 'scripts/statistics.py'
+            command: 'statistics.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
@@ -231,8 +247,9 @@ cycles:
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/merge.py'
-            cli arguments: []
+            src: 'scripts/merge.py'
+            command: 'merge.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []
   - yearly [date: 2027-01-01 00:00:00]:
       tasks:
@@ -246,6 +263,7 @@ cycles:
             coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
             cycle point: [2027-01-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/merge.py'
-            cli arguments: []
+            src: 'scripts/merge.py'
+            command: 'merge.py {PORT::None}'
+            multi arg sep: ' '
             env source files: []

--- a/tests/cases/parameters/data/config.txt
+++ b/tests/cases/parameters/data/config.txt
@@ -14,7 +14,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2026-01-01 00:00:00]:
             input:
@@ -29,7 +28,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2026-01-01 00:00:00]:
             input:
@@ -43,7 +41,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2026-01-01 00:00:00]:
             input:
@@ -56,7 +53,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
   - bimonthly_tasks [date: 2026-07-01 00:00:00]:
       tasks:
@@ -73,7 +69,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2026-07-01 00:00:00]:
             input:
@@ -88,7 +83,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2026-07-01 00:00:00]:
             input:
@@ -102,7 +96,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2026-07-01 00:00:00]:
             input:
@@ -115,7 +108,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
   - bimonthly_tasks [date: 2027-01-01 00:00:00]:
       tasks:
@@ -132,7 +124,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2027-01-01 00:00:00]:
             input:
@@ -147,7 +138,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2027-01-01 00:00:00]:
             input:
@@ -161,7 +151,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2027-01-01 00:00:00]:
             input:
@@ -174,7 +163,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
   - bimonthly_tasks [date: 2027-07-01 00:00:00]:
       tasks:
@@ -191,7 +179,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2027-07-01 00:00:00]:
             input:
@@ -206,7 +193,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo [bar: 3.0, date: 2027-07-01 00:00:00]:
             input:
@@ -220,7 +206,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
         - statistics_foo_bar [date: 2027-07-01 00:00:00]:
             input:
@@ -233,7 +218,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/statistics.py'
             command: 'statistics.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
       tasks:
@@ -249,7 +233,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/merge.py'
             command: 'merge.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []
   - yearly [date: 2027-01-01 00:00:00]:
       tasks:
@@ -265,5 +248,4 @@ cycles:
             plugin: 'shell'
             src: 'scripts/merge.py'
             command: 'merge.py {PORT::None}'
-            multi arg sep: ' '
             env source files: []

--- a/tests/cases/small/config/config.yml
+++ b/tests/cases/small/config/config.yml
@@ -11,7 +11,7 @@ cycles:
         - icon:
             inputs:
               - icon_namelist:
-                  port: namelist
+                  port: UNUSED
               - initial_conditions:
                   when:
                     at: *root_start_date
@@ -36,7 +36,7 @@ tasks:
       computer: localhost
       plugin: shell
       src: scripts/icon.py
-      command: "icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}"
+      command: "icon.py --restart {PORT::restart} --init {PORT::init}"
       env_source_files: data/dummy_source_file.sh
   - cleanup:
       computer: localhost

--- a/tests/cases/small/config/config.yml
+++ b/tests/cases/small/config/config.yml
@@ -10,7 +10,8 @@ cycles:
       tasks:
         - icon:
             inputs:
-              - icon_namelist
+              - icon_namelist:
+                  port: namelist
               - initial_conditions:
                   when:
                     at: *root_start_date
@@ -35,7 +36,7 @@ tasks:
       computer: localhost
       plugin: shell
       src: scripts/icon.py
-      command: "icon.py --restart {PORT::restart} --init {PORT::init}"
+      command: "icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}"
       env_source_files: data/dummy_source_file.sh
   - cleanup:
       computer: localhost

--- a/tests/cases/small/config/config.yml
+++ b/tests/cases/small/config/config.yml
@@ -14,6 +14,8 @@ cycles:
               - initial_conditions:
                   when:
                     at: *root_start_date
+                  port:
+                    init
               - icon_restart:
                   when:
                     after: *root_start_date
@@ -32,13 +34,14 @@ tasks:
   - icon:
       computer: localhost
       plugin: shell
-      command: scripts/icon.py
-      cli_arguments: "{--restart icon_restart} {--init initial_conditions}"
+      src: scripts/icon.py
+      command: "icon.py --restart {PORT::restart} --init {PORT::init}"
       env_source_files: data/dummy_source_file.sh
   - cleanup:
       computer: localhost
       plugin: shell
-      command: scripts/cleanup.py
+      src: scripts/cleanup.py
+      command: "cleanup.py"
 data:
   available:
      - icon_namelist:

--- a/tests/cases/small/config/config.yml
+++ b/tests/cases/small/config/config.yml
@@ -36,7 +36,7 @@ tasks:
       computer: localhost
       plugin: shell
       src: scripts/icon.py
-      command: "icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}"
+      command: "icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}"
       env_source_files: data/dummy_source_file.sh
   - cleanup:
       computer: localhost

--- a/tests/cases/small/data/config.txt
+++ b/tests/cases/small/data/config.txt
@@ -14,7 +14,7 @@ cycles:
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
@@ -31,7 +31,7 @@ cycles:
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
@@ -48,7 +48,7 @@ cycles:
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
             env source files: ['data/dummy_source_file.sh']
   - lastly:
       tasks:

--- a/tests/cases/small/data/config.txt
+++ b/tests/cases/small/data/config.txt
@@ -14,7 +14,7 @@ cycles:
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}'
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
@@ -31,7 +31,7 @@ cycles:
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}'
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
@@ -48,7 +48,7 @@ cycles:
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}'
             env source files: ['data/dummy_source_file.sh']
   - lastly:
       tasks:

--- a/tests/cases/small/data/config.txt
+++ b/tests/cases/small/data/config.txt
@@ -14,7 +14,7 @@ cycles:
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}'
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
@@ -31,7 +31,7 @@ cycles:
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}'
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
@@ -48,7 +48,7 @@ cycles:
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
             src: 'scripts/icon.py'
-            command: 'icon.py --restart {PORT::restart} --init {PORT::init} --namelist {PORT::namelist}'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init} {PORT:namelist}'
             env source files: ['data/dummy_source_file.sh']
   - lastly:
       tasks:

--- a/tests/cases/small/data/config.txt
+++ b/tests/cases/small/data/config.txt
@@ -13,8 +13,9 @@ cycles:
             computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
@@ -30,8 +31,9 @@ cycles:
             computer: 'localhost'
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
@@ -47,8 +49,9 @@ cycles:
             computer: 'localhost'
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
-            command: 'scripts/icon.py'
-            cli arguments: [ShellCliArgument(name='icon_restart', references_data_item=True, cli_option_of_data_item='--restart'), ShellCliArgument(name='initial_conditions', references_data_item=True, cli_option_of_data_item='--init')]
+            src: 'scripts/icon.py'
+            command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
+            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
   - lastly:
       tasks:
@@ -60,6 +63,7 @@ cycles:
             computer: 'localhost'
             cycle point: []
             plugin: 'shell'
-            command: 'scripts/cleanup.py'
-            cli arguments: []
+            src: 'scripts/cleanup.py'
+            command: 'cleanup.py'
+            multi arg sep: ' '
             env source files: []

--- a/tests/cases/small/data/config.txt
+++ b/tests/cases/small/data/config.txt
@@ -15,7 +15,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
@@ -33,7 +32,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
@@ -51,7 +49,6 @@ cycles:
             plugin: 'shell'
             src: 'scripts/icon.py'
             command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
-            multi arg sep: ' '
             env source files: ['data/dummy_source_file.sh']
   - lastly:
       tasks:
@@ -65,5 +62,4 @@ cycles:
             plugin: 'shell'
             src: 'scripts/cleanup.py'
             command: 'cleanup.py'
-            multi arg sep: ' '
             env source files: []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def minimal_config() -> models.ConfigWorkflow:
         name="minimal",
         rootdir=pathlib.Path("minimal"),
         cycles=[models.ConfigCycle(name="minimal", tasks=[models.ConfigCycleTask(name="some_task")])],
-        tasks=[models.ConfigShellTask(name="some_task")],
+        tasks=[models.ConfigShellTask(name="some_task", command="some_command")],
         data=models.ConfigData(
             available=[models.ConfigAvailableData(name="foo", type=models.DataType.FILE, src="foo.txt")],
             generated=[models.ConfigGeneratedData(name="bar", type=models.DataType.DIR, src="bar")],

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -4,25 +4,8 @@ import pytest
 
 from sirocco.core import Workflow
 from sirocco.core._tasks.icon_task import IconTask
-from sirocco.parsing.yaml_data_models import ConfigShellTask, ShellCliArgument
 from sirocco.vizgraph import VizGraph
 from sirocco.workgraph import AiidaWorkGraph
-
-
-# configs that are tested for parsing
-def test_parsing_cli_parameters():
-    cli_arguments = "-D --CMAKE_CXX_COMPILER=${CXX_COMPILER} {--init file}"
-    assert ConfigShellTask.split_cli_arguments(cli_arguments) == [
-        "-D",
-        "--CMAKE_CXX_COMPILER=${CXX_COMPILER}",
-        "{--init file}",
-    ]
-
-    assert ConfigShellTask.parse_cli_arguments(cli_arguments) == [
-        ShellCliArgument("-D", False, None),
-        ShellCliArgument("--CMAKE_CXX_COMPILER=${CXX_COMPILER}", False, None),
-        ShellCliArgument("file", True, "--init"),
-    ]
 
 
 def test_parse_config_file(config_paths, pprinter):

--- a/tests/unit_tests/core/test_workflow.py
+++ b/tests/unit_tests/core/test_workflow.py
@@ -1,5 +1,5 @@
 from sirocco import pretty_print
-from sirocco.core import Workflow
+from sirocco.core import AvailableData, Workflow
 
 # NOTE: import of ShellTask is required to populated in Task.plugin_classes in __init_subclass__
 from sirocco.core._tasks.shell_task import ShellTask  # noqa: F401
@@ -12,5 +12,5 @@ def test_minimal_workflow(minimal_config):
 
     assert len(list(testee.tasks)) == 1
     assert len(list(testee.cycles)) == 1
-    assert testee.data[("foo", {})].available
+    assert isinstance(testee.data[("foo", {})], AvailableData)
     assert testee.config_rootdir == minimal_config.rootdir

--- a/tests/unit_tests/parsing/test_yaml_data_models.py
+++ b/tests/unit_tests/parsing/test_yaml_data_models.py
@@ -33,6 +33,7 @@ def minimal_config_path(tmp_path):
         tasks:
           - b:
               plugin: shell
+              command: some_command
         data:
           available:
             - c:


### PR DESCRIPTION
### `Task.inputs` is now a dictionary
`Task.inputs` is now a dict mapping the ports to the list of corresponding input data. If no port is specified in the config file, it defaults to `None`. If the port information isn't needed, the `task.input_task_nodes` iterator is introduce for convenience, to directly iterate over all the input data nodes without having to inspect the dict.

### Use `{PORT::...}` placeholders in the command line
We don't parse the command line anymore apart from the `{PORT::port_name}` placeholders. This is made possible by the ability to specify arguments of a shell task by a single string instead of a list of strings. This way the format of the command line is entirely in the hands of the user. It also removes a lot of the ad-hoc code.

`command` and `arguments` are now all specified in the single `command` string

The only assumption we make is for multiple arguments corresponding to a single port. There we expend the list of arguments with a separator defaulting to `" "`. Specifying an alternative separator, e.g. for a comma, is done via `"{PORT[sep=,]::port_name}"`

### Some additional minor refactoring for readability