### PR TITLE
Update dependency aiida-workgraph to v0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "pydantic",
   "ruamel.yaml",
   "aiida-core>=2.5",
-  "aiida-workgraph==0.4.10",
+  "aiida-workgraph==0.5.2",
   "termcolor",
   "pygraphviz",
   "lxml",

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -43,8 +43,10 @@ def test_run_workgraph(config_case, config_paths, aiida_computer):  # noqa: ARG0
 
     core_workflow = Workflow.from_config_file(str(config_paths["yml"]))
     aiida_workflow = AiidaWorkGraph(core_workflow)
-    out = aiida_workflow.run()
-    assert out.get("execution_count", None).value == 1
+    output_node = aiida_workflow.run()
+    assert (
+        output_node.is_finished_ok
+    ), f"Not successful run. Got exit code {output_node.exit_code} with message {output_node.exit_message}."
 
 
 # configs containing task using icon plugin


### PR DESCRIPTION
aiida-workgraph v0.4.10 has bug when passing a builder as task identifier, here an example from the doc that does not work:

```
builder = ArithmeticAddCalculation.get_builder()
builder.code = load_code("bash@localhost")
builder.x = Int(2)
builder.y = Int(3)

wg = WorkGraph("test_set_inputs_from_builder")
add1 = wg.add_task(builder, name="add1")
```

This has been fixed in v0.5.2 but as `prepare_for_shell_task` has changed its signature and does not take anymore the `task` argument we have to move the workaround a level higher where `prepare_for_shell_task` is used and where we have access to the `task`.