### PR TITLE
Include ports to `ConfigCycleTaskOutput` and `Data`

### DIFF
--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -173,6 +173,8 @@ class ConfigCycleTaskOutput(_NamedBaseModel):
     To create an instance of an output in a task in a cycle defined in a workflow file.
     """
 
+    port: str | None = None
+
 
 NAMED_BASE_T = typing.TypeVar("NAMED_BASE_T", bound=_NamedBaseModel)
 

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -139,7 +139,7 @@ class PrettyPrinter:
             sections.append(
                 self.as_block(
                     "output",
-                    "\n".join(self.as_item(self.format_basic(output)) for output in obj.outputs),
+                    "\n".join(self.as_item(self.format_basic(output)) for output in obj.output_data_nodes()),
                 )
             )
         if obj.wait_on:

--- a/src/sirocco/vizgraph.py
+++ b/src/sirocco/vizgraph.py
@@ -58,7 +58,7 @@ class VizGraph:
                 )
                 for data_node in task_node.input_data_nodes():
                     self.agraph.add_edge(data_node, task_node, **self.io_edge_kw)
-                for data_node in task_node.outputs:
+                for data_node in task_node.output_data_nodes():
                     self.agraph.add_edge(task_node, data_node, **self.io_edge_kw)
                     cluster_nodes.append(data_node)
                 for wait_task_node in task_node.wait_on:

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -93,7 +93,7 @@ class AiidaWorkGraph:
         for task in self._core_workflow.tasks:
             self.create_task_node(task)
             # Create and link corresponding output sockets
-            for output in task.outputs:
+            for output in task.output_data_nodes():
                 self._link_output_node_to_task(task, output)
 
         # link input nodes to workgraph tasks
@@ -124,7 +124,7 @@ class AiidaWorkGraph:
                 except ValueError as exception:
                     msg = f"Raised error when validating input name '{input_.name}': {exception.args[0]}"
                     raise ValueError(msg) from exception
-            for output in task.outputs:
+            for output in task.output_data_nodes():
                 try:
                     aiida.common.validate_link_label(output.name)
                 except ValueError as exception:

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -42,7 +42,13 @@ cycles:
                   target_cycle:
                     lag: '-P2M'
                   port: restart
-            outputs: [stream_1, stream_2, icon_restart]
+            outputs:
+              - stream_1:
+                  port: stream1
+              - stream_2:
+                  port: stream2
+              - icon_restart:
+                  port: restart_file
         - postproc_1:
             inputs:
               - stream_1:


### PR DESCRIPTION
Outputs now also can have an optional port. This change is required for icon task that uses the `IconCalculation` aiida calcjob to run icon. Unlike the aiida `ShellJob` that creates output ports dynamically from the `output.src` information, the `IconCalculation` defines fixed output ports for each type of output. For example to reference the outputted restart file we need to write a config of the form.

```yaml
  outputs:
    - restart:
        port: restart_file
```

The disadvantage of this design to support ports for outputs is that one can also specify ports for the `ShellTask` outputs where it is not needed. My solution to this problem is to notify the user with a warning that this does not have any effect.

We need the `graph_spec.outputs` information of the spec in the children classes of the Task (`ShellTask` and `IconTask` in a future PR) to resolve the data port differently. To have this information available in the children class instead of passing the `graph_spec.outpus` where the port information resides to the __init__ constructor, I  added the port information to the `Data` object that is already passed to the children class. This is an easier approach, since we use dataclass decorator for the children classes creating a custom __init__ constructor which is a bit cumbersome to overload. To be more consistent I also adapted the inputs to the same approach so we use the same type for inputs and outputs. I added a method to obtain inputs by ports that can be made more efficient by caching and a O(n log n) algorithm, if this this becomes ever a bottleneck
