### PR TITLE
Add integration ci that installs icon

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       env:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
-        hatch test -m "slow or not requires_icon" --parallel --cover
+        hatch test -m "not requires_icon" --parallel --cover
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       env:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
-        hatch test -m "" --parallel --cover # override default exclusion of slow tests with -m ""
+        hatch test -m "slow or not requires_icon" --parallel --cover
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,0 +1,60 @@
+name: test-integration
+
+on:
+  push:
+    # only pushes to main trigger
+    branches: [main]
+  pull_request:
+    # always triggered
+
+jobs:
+  integration_test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120 # when icon needs to be rebuild it can take 70 minutes
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        aiida-version: ['stable']
+
+    permissions:
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Spack
+      uses: spack/setup-spack@v2
+      with:
+        buildcache: true
+
+    - name: Install Python and ICON
+      env:
+        SPACK_OCI_USER: leclairm
+        SPACK_OCI_TOKEN: ${{ secrets.SPACK_OCI_TOKEN }}
+      run: |
+        sudo apt install gcc-11 g++-11 gfortran-11 graphviz graphviz-dev
+        spack -e . add python@${{matrix.python-version}}
+        spack -e . install
+
+    - name: Push installation to buildcache and update index
+      env:
+        SPACK_OCI_USER: leclairm
+        SPACK_OCI_TOKEN: ${{ secrets.SPACK_OCI_TOKEN }}
+      run: spack -e . buildcache push --base-image ubuntu:latest --update-index local-buildcache
+      if: ${{ !cancelled() }}
+
+    - name: Install hatch
+      shell: spack-bash {0}
+      run: |
+        spack env activate .
+        pip install --upgrade pip 
+        pip install hatch
+        hatch run verdi presto
+
+    - name: Run ICON tests
+      shell: spack-bash {0}
+      env:
+        PYTEST_ADDOPTS: "--durations=0"
+      run: |
+        spack env activate .
+        hatch test -m "requires_icon" --parallel tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ Changelog = "https://github.com/C2SM/Sirocco/blob/main/CHANGELOG.md"
 addopts = "--pdbcls=IPython.terminal.debugger:TerminalPdb"
 norecursedirs = "tests/cases"
 markers = [
-  "slow: slow integration tests which are not recommended to run locally for normal development"
+  "slow: slow integration tests which are not recommended to run locally for normal development",
+  "requires_icon: marks test to require icon installation"
 ]
 filterwarnings = [
   "error",
@@ -93,7 +94,7 @@ extra-dependencies = [
     "ipdb"
 ]
 default-args = []
-extra-args = ["--doctest-modules", '-m not slow']
+extra-args = ["--doctest-modules", '-m not slow', '-m not requires_icon']
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.12"]
@@ -128,7 +129,8 @@ extra-dependencies = [
   "types-docutils",
   "types-colorama",
   "types-Pygments",
-  "types-termcolor"
+  "types-termcolor",
+  "types-requests"
 ]
 
 [tool.hatch.envs.types.scripts]

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,7 +3,7 @@ spack:
   specs:
   - icon ~aes ~jsbach ~ocean ~coupling ~rte-rrtmgp
 
-  'compilers:':
+  compilers:
   - compiler:
       spec: gcc@11.4.0
       paths:

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,37 @@
+spack:
+  view: /opt/view
+  specs:
+  - icon ~aes ~jsbach ~ocean ~coupling ~rte-rrtmgp
+
+  'compilers:':
+  - compiler:
+      spec: gcc@11.4.0
+      paths:
+        cc: /usr/bin/gcc-11
+        cxx: /usr/bin/g++-11
+        f77: /usr/bin/gfortran-11
+        fc: /usr/bin/gfortran-11
+      flags: {}
+      operating_system: ubuntu24.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  config:
+    install_tree:
+      root: /opt/spack
+      padded_length: 128
+
+  packages:
+    all:
+      require: target=x86_64
+
+  mirrors:
+    local-buildcache:
+      url: oci://ghcr.io/leclairm/spack-buildcache
+      binary: true
+      signed: false
+      access_pair:
+        id: SPACK_OCI_USER
+        secret_variable: SPACK_OCI_TOKEN #  NOTE to generate a new token one has to go to developer settings -> token classics with "write:packages" permission and then add this token as secret to the repo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
+import logging
 import pathlib
+import subprocess
 
 import pytest
+import requests
 
 from sirocco import pretty_print
 from sirocco.core import _tasks as core_tasks
@@ -8,6 +11,49 @@ from sirocco.core import workflow
 from sirocco.parsing import yaml_data_models as models
 
 pytest_plugins = ["aiida.tools.pytest_fixtures"]
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DownloadError(RuntimeError):
+    def __init__(self, url: str, response: requests.Response):
+        super().__init__(f"Failed downloading file {url} , exited with response {response}")
+
+
+def download_file(url: str, file_path: pathlib.Path):
+    response = requests.get(url)
+    if not response.ok:
+        raise DownloadError(url, response)
+
+    file_path.write_bytes(response.content)
+
+
+@pytest.fixture(scope="module")
+def icon_grid_simple_path(pytestconfig):
+    url = "https://github.com/agoscinski/icon-testfiles/raw/refs/heads/main/icon_grid_0013_R02B04_R.nc"
+    filename = "icon_grid_simple.nc"
+    cache_dir = pytestconfig.cache.mkdir("downloaded_files")
+    icon_grid_path = cache_dir / filename
+
+    # Check if the file is already cached
+    if icon_grid_path.exists():
+        LOGGER.info("Found icon grid in cache, reusing it.")
+    else:
+        # File is not cached, download and save it
+        LOGGER.info("Downloading and caching icon grid.")
+        download_file(url, icon_grid_path)
+
+    return icon_grid_path
+
+
+@pytest.fixture
+def icon_filepath_executable() -> str:
+    which_icon = subprocess.run(["which", "icon"], capture_output=True, check=False)
+    if which_icon.returncode:
+        msg = "Could not find icon executable."
+        raise FileNotFoundError(msg)
+
+    return which_icon.stdout.decode().strip()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -23,6 +23,13 @@ def test_vizgraph(config_paths):
     VizGraph.from_config_file(config_paths["yml"]).draw(file_path=config_paths["svg"])
 
 
+@pytest.mark.requires_icon
+@pytest.mark.usefixtures("icon_filepath_executable", "icon_grid_simple_path")
+def test_icon():
+    # Test is performed by fixtures
+    pass
+
+
 # configs that are tested for running workgraph
 @pytest.mark.slow
 @pytest.mark.parametrize(


### PR DESCRIPTION
New CI workflow icon-tests that installs icon using spack and runs the tests assigned with the marker icon_required.

We use the spack buildcache feature to reuse a previous icon installation in the CI to reduce the CI time drastically (from 70 mins to 3 mins)

Because we need to activate the spack shell to access the icon installation the python version that required for icon is also activated. We thus use for this new workflow the spack python version instead of the one of actions/setup-python like in the unittests workflow.