### PR TITLE
Enforce usage of absolute path and computer

### DIFF
--- a/src/sirocco/core/_tasks/icon_task.py
+++ b/src/sirocco/core/_tasks/icon_task.py
@@ -95,7 +95,7 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
             namelist.dump(directory / filename)
 
     @classmethod
-    def build_from_config(cls: type[Self], config: models.ConfigTask, **kwargs: Any) -> Self:
+    def build_from_config(cls: type[Self], config: models.ConfigTask, config_rootdir: Path, **kwargs: Any) -> Self:
         config_kwargs = dict(config)
         del config_kwargs["parameters"]
         # The following check is here for type checkers.
@@ -105,10 +105,12 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
             raise TypeError
 
         config_kwargs["namelists"] = [
-            NamelistFile.from_config(config=config_namelist) for config_namelist in config_kwargs["namelists"]
+            NamelistFile.from_config(config=config_namelist, config_rootdir=config_rootdir)
+            for config_namelist in config_kwargs["namelists"]
         ]
 
         self = cls(
+            config_rootdir=config_rootdir,
             **kwargs,
             **config_kwargs,
         )

--- a/src/sirocco/core/_tasks/icon_task.py
+++ b/src/sirocco/core/_tasks/icon_task.py
@@ -32,7 +32,6 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
             msg = f"Failed to read master namelists. Could not find {self._MASTER_NAMELIST_NAME!r} in namelists {self.namelists}"
             raise ValueError(msg)
         self._master_namelist = master_namelist
-        self.src = self._validate_src(self.src, self.config_rootdir)
 
         # retrieve model namelist name from master namelist
         if (master_model_nml := self._master_namelist.namelist.get(self._MASTER_MODEL_NML_SECTION, None)) is None:
@@ -106,8 +105,7 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
             raise TypeError
 
         config_kwargs["namelists"] = [
-            NamelistFile.from_config(config=config_namelist, config_rootdir=kwargs["config_rootdir"])
-            for config_namelist in config_kwargs["namelists"]
+            NamelistFile.from_config(config=config_namelist) for config_namelist in config_kwargs["namelists"]
         ]
 
         self = cls(
@@ -116,18 +114,3 @@ class IconTask(models.ConfigIconTaskSpecs, Task):
         )
         self.update_icon_namelists_from_workflow()
         return self
-
-    @staticmethod
-    def _validate_src(config_src: Path, config_rootdir: Path | None = None) -> Path:
-        if config_rootdir is None and not config_src.is_absolute():
-            msg = f"Cannot specify relative path {config_src} for namelist while the rootdir is None"
-            raise ValueError(msg)
-
-        src = config_src if config_rootdir is None else (config_rootdir / config_src)
-        if not src.exists():
-            msg = f"Icon executable in path {src} does not exist."
-            raise FileNotFoundError(msg)
-        if not src.is_file():
-            msg = f"Icon executable in path {src} is not a file."
-            raise OSError(msg)
-        return src

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -140,10 +140,10 @@ class Task(ConfigBaseTaskSpecs, GraphItem):
         return new
 
     @classmethod
-    def build_from_config(cls: type[Self], config: ConfigTask, **kwargs: Any) -> Self:
+    def build_from_config(cls: type[Self], config: ConfigTask, config_rootdir: Path, **kwargs: Any) -> Self:
         config_kwargs = dict(config)
         del config_kwargs["parameters"]
-        return cls(**kwargs, **config_kwargs)
+        return cls(config_rootdir=config_rootdir, **kwargs, **config_kwargs)
 
     def link_wait_on_tasks(self, taskstore: Store[Task]) -> None:
         self.wait_on = list(

--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -45,53 +45,19 @@ class Data(ConfigBaseDataSpecs, GraphItem):
     color: ClassVar[str] = field(default="light_blue", repr=False)
 
     @classmethod
-    def from_config(
-        cls, config: ConfigBaseData, config_rootdir: Path, coordinates: dict
-    ) -> AvailableData | GeneratedData:
+    def from_config(cls, config: ConfigBaseData, coordinates: dict) -> AvailableData | GeneratedData:
         data_class = AvailableData if isinstance(config, ConfigAvailableData) else GeneratedData
-
-        return data_class.from_config(
-            config=config,
-            config_rootdir=config_rootdir,
-            coordinates=coordinates,
-        )
+        config_kwargs = dict(config)
+        del config_kwargs["parameters"]
+        return data_class(coordinates=coordinates, **config_kwargs)
 
 
 class AvailableData(Data):
     src: Path
 
-    @classmethod
-    def from_config(cls, config: ConfigBaseData, config_rootdir: Path, coordinates: dict) -> Self:
-        src = cls._validate_src(config.src, config_rootdir)
-        return cls(
-            name=config.name,
-            computer=config.computer,
-            type=config.type,
-            src=src,
-            coordinates=coordinates,
-        )
-
-    @staticmethod
-    def _validate_src(config_src: Path | None, config_rootdir: Path | None = None) -> Path | None:
-        if config_src is None:
-            return None
-        if config_rootdir is None and not config_src.is_absolute():
-            msg = f"Cannot specify relative path {config_src} for namelist while the rootdir is None"
-            raise ValueError(msg)
-
-        return config_src if config_rootdir is None else (config_rootdir / config_src)
-
 
 class GeneratedData(Data):
-    @classmethod
-    def from_config(cls, config: ConfigBaseData, config_rootdir: Path, coordinates: dict) -> Self:  # noqa: ARG003 # we need to keep same signature as for AvailableData
-        return cls(
-            name=config.name,
-            computer=config.computer,
-            type=config.type,
-            src=config.src,
-            coordinates=coordinates,
-        )
+    pass
 
 
 @dataclass(kw_only=True)

--- a/src/sirocco/core/namelistfile.py
+++ b/src/sirocco/core/namelistfile.py
@@ -1,4 +1,3 @@
-import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -24,8 +23,8 @@ class NamelistFile(models.ConfigNamelistFileSpec):
         self._namelist = f90nml.read(self.path)
 
     @classmethod
-    def from_config(cls: type[Self], config: models.ConfigNamelistFile) -> Self:
-        path = cls._validate_namelist_path(config.path)
+    def from_config(cls: type[Self], config: models.ConfigNamelistFile, config_rootdir: Path) -> Self:
+        path = cls._validate_namelist_path(config.path, config_rootdir)
         self = cls(path=path)
         self.update_from_specs(config.specs)
         return self
@@ -60,15 +59,19 @@ class NamelistFile(models.ConfigNamelistFileSpec):
         self.namelist.write(path)
 
     @staticmethod
-    def _validate_namelist_path(config_namelist_path: Path) -> Path:
-        namelist_path = Path(os.path.expandvars(config_namelist_path))
+    def _validate_namelist_path(config_namelist_path: Path, config_rootdir: Path | None = None) -> Path:
+        if config_rootdir is None and not config_namelist_path.is_absolute():
+            msg = f"Cannot specify relative path {config_namelist_path} for namelist while the rootdir is None"
+            raise ValueError(msg)
+
+        namelist_path = config_namelist_path if config_rootdir is None else (config_rootdir / config_namelist_path)
         if not namelist_path.is_absolute():
-            msg = f"Namelist in path {config_namelist_path} expanded to {namelist_path} is not absolute path."
+            msg = f"Namelist path {namelist_path} must be relative with respect to config file."
         if not namelist_path.exists():
-            msg = f"Namelist in path {config_namelist_path} expanded to {namelist_path} does not exist."
+            msg = f"Namelist in path {namelist_path} does not exist."
             raise FileNotFoundError(msg)
         if not namelist_path.is_file():
-            msg = f"Namelist in path {config_namelist_path} expanded to {namelist_path} is not a file."
+            msg = f"Namelist in path {namelist_path} is not a file."
             raise OSError(msg)
         return namelist_path
 

--- a/src/sirocco/core/namelistfile.py
+++ b/src/sirocco/core/namelistfile.py
@@ -60,13 +60,13 @@ class NamelistFile(models.ConfigNamelistFileSpec):
 
     @staticmethod
     def _validate_namelist_path(config_namelist_path: Path, config_rootdir: Path | None = None) -> Path:
+        if config_namelist_path.is_absolute():
+            msg = f"Namelist path {config_namelist_path} must be relative with respect to config file."
         if config_rootdir is None and not config_namelist_path.is_absolute():
             msg = f"Cannot specify relative path {config_namelist_path} for namelist while the rootdir is None"
             raise ValueError(msg)
 
         namelist_path = config_namelist_path if config_rootdir is None else (config_rootdir / config_namelist_path)
-        if not namelist_path.is_absolute():
-            msg = f"Namelist path {namelist_path} must be relative with respect to config file."
         if not namelist_path.exists():
             msg = f"Namelist in path {namelist_path} does not exist."
             raise FileNotFoundError(msg)

--- a/src/sirocco/core/namelistfile.py
+++ b/src/sirocco/core/namelistfile.py
@@ -18,7 +18,6 @@ class NamelistFile(models.ConfigNamelistFileSpec):
     name: str = field(init=False)
 
     def __post_init__(self) -> None:
-        self.path = self._validate_namelist_path(self.path)
         self.name = self.path.name
         self._namelist = f90nml.read(self.path)
 
@@ -59,13 +58,9 @@ class NamelistFile(models.ConfigNamelistFileSpec):
         self.namelist.write(path)
 
     @staticmethod
-    def _validate_namelist_path(config_namelist_path: Path, config_rootdir: Path | None = None) -> Path:
+    def _validate_namelist_path(config_namelist_path: Path, config_rootdir: Path) -> Path:
         if config_namelist_path.is_absolute():
             msg = f"Namelist path {config_namelist_path} must be relative with respect to config file."
-        if config_rootdir is None and not config_namelist_path.is_absolute():
-            msg = f"Cannot specify relative path {config_namelist_path} for namelist while the rootdir is None"
-            raise ValueError(msg)
-
         namelist_path = config_namelist_path if config_rootdir is None else (config_rootdir / config_namelist_path)
         if not namelist_path.exists():
             msg = f"Namelist in path {namelist_path} does not exist."

--- a/src/sirocco/core/workflow.py
+++ b/src/sirocco/core/workflow.py
@@ -56,11 +56,7 @@ class Workflow:
         # 1 - create availalbe data nodes
         for available_data_config in config_data.available:
             for coordinates in iter_coordinates(OneOffPoint(), available_data_config.parameters):
-                self.data.add(
-                    Data.from_config(
-                        config=available_data_config, config_rootdir=config_rootdir, coordinates=coordinates
-                    )
-                )
+                self.data.add(Data.from_config(config=available_data_config, coordinates=coordinates))
 
         # 2 - create output data nodes
         for cycle_config in config_cycles:
@@ -69,11 +65,7 @@ class Workflow:
                     for data_ref in task_ref.outputs:
                         data_config = config_data_dict[data_ref.name]
                         for coordinates in iter_coordinates(cycle_point, data_config.parameters):
-                            self.data.add(
-                                Data.from_config(
-                                    config=data_config, config_rootdir=config_rootdir, coordinates=coordinates
-                                )
-                            )
+                            self.data.add(Data.from_config(config=data_config, coordinates=coordinates))
 
         # 3 - create cycles and tasks
         for cycle_config in config_cycles:

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -442,9 +442,6 @@ class ConfigNamelistFile(BaseModel, ConfigNamelistFileSpec):
 @dataclass(kw_only=True)
 class ConfigIconTaskSpecs:
     plugin: ClassVar[Literal["icon"]] = "icon"
-    # PRCOMMENT this is later resolved to an absolute path so we cannot use it for serialization
-    #           as the tests would fail. Since the main purpose of the repr is for regression tests
-    #           I disable its prnting here
     src: Path = field(repr=False)
 
 

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -250,7 +250,7 @@ class ConfigBaseTaskSpecs:
     Any of these keys can be None, in which case they are inherited from the root task.
     """
 
-    computer: str | None = None
+    computer: str
     host: str | None = None
     account: str | None = None
     uenv: dict | None = None
@@ -360,6 +360,7 @@ class ConfigShellTask(ConfigBaseTask, ConfigShellTaskSpecs):
         ...         '''
         ...     my_task:
         ...       plugin: shell
+        ...       computer: localhost
         ...       command: "my_script.sh -n 1024 {PORT::current_sim_output}"
         ...       src: post_run_scripts/my_script.sh
         ...       env_source_files: "env.sh"
@@ -459,6 +460,7 @@ class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
         ...     '''
         ...       ICON:
         ...         plugin: icon
+        ...         computer: localhost
         ...         namelists:
         ...           - path/to/icon_master.namelist
         ...           - path/to/case_nml:
@@ -632,6 +634,7 @@ class ConfigWorkflow(BaseModel):
             ...     tasks:
             ...       - task_a:
             ...           plugin: shell
+            ...           computer: localhost
             ...           command: "some_command"
             ...     data:
             ...       available:
@@ -653,7 +656,13 @@ class ConfigWorkflow(BaseModel):
             ...     rootdir=Path("/location/of/config/file"),
             ...     cycles=[ConfigCycle(minimal_cycle={"tasks": [ConfigCycleTask(task_a={})]})],
             ...     tasks=[
-            ...         ConfigShellTask(task_a={"plugin": "shell", "command": "some_command"})
+            ...         ConfigShellTask(
+            ...             task_a={
+            ...                 "plugin": "shell",
+            ...                 "computer": "localhost",
+            ...                 "command": "some_command",
+            ...             }
+            ...         )
             ...     ],
             ...     data=ConfigData(
             ...         available=[

--- a/src/sirocco/pretty_print.py
+++ b/src/sirocco/pretty_print.py
@@ -91,6 +91,7 @@ class PrettyPrinter:
         ...     PrettyPrinter().format_basic(
         ...         core.Task(
         ...             name="foo",
+        ...             computer="localhost",
         ...             config_rootdir=pathlib.Path("."),
         ...             cycle_point=DateCyclePoint(
         ...                 start_date=datetime(1000, 1, 1),

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -196,8 +196,6 @@ class AiidaWorkGraph:
             except NotExistent as err:
                 msg = f"Could not find computer {data.computer!r} for input {data}."
                 raise ValueError(msg) from err
-            # `remote_path` must be str not PosixPath to be JSON-serializable
-            # FIXME: should not use resolved relative path, will be fixed in PR #153
             self._aiida_data_nodes[label] = aiida.orm.RemoteData(
                 remote_path=str(data.src), label=label, computer=computer
             )

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -235,7 +235,6 @@ class AiidaWorkGraph:
         from aiida_shell import ShellCode
 
         label_uuid = str(uuid.uuid4())
-        # PRCOMMENT aiida-shell created the code before from the command we passed but this only works if it can resolve commands. Since we now want to support environment variables that possibly cannot be resoved until submission (because it uses environment variables in one of the source files)
         code = ShellCode(
             label=f"{command}-{label_uuid}",
             computer=aiida.orm.load_computer(task.computer),

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import io
+import os
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
@@ -188,7 +189,6 @@ class AiidaWorkGraph:
         Create an `aiida.orm.Data` instance from the provided graph item.
         """
         label = self.get_aiida_label_from_graph_item(data)
-        data_full_path = data.src if data.src.is_absolute() else self._core_workflow.config_rootdir / data.src
 
         if data.computer is not None:
             try:
@@ -199,12 +199,12 @@ class AiidaWorkGraph:
             # `remote_path` must be str not PosixPath to be JSON-serializable
             # FIXME: should not use resolved relative path, will be fixed in PR #153
             self._aiida_data_nodes[label] = aiida.orm.RemoteData(
-                remote_path=str(data_full_path), label=label, computer=computer
+                remote_path=str(data.src), label=label, computer=computer
             )
-        elif data.type == "file":
-            self._aiida_data_nodes[label] = aiida.orm.SinglefileData(label=label, file=data_full_path)
-        elif data.type == "dir":
-            self._aiida_data_nodes[label] = aiida.orm.FolderData(label=label, tree=data_full_path)
+        elif data.computer is None and data.type == "file":
+            self._aiida_data_nodes[label] = aiida.orm.SinglefileData(label=label, file=os.path.expandvars(data.src))
+        elif data.computer is None and data.type == "dir":
+            self._aiida_data_nodes[label] = aiida.orm.FolderData(label=label, tree=os.path.expandvars(data.src))
         else:
             msg = f"Data type {data.type!r} not supported. Please use 'file' or 'dir'."
             raise ValueError(msg)
@@ -232,18 +232,25 @@ class AiidaWorkGraph:
             if task.src is None:
                 msg = "src must be specified when command path is relative"
                 raise ValueError(msg)
-            command = str((task.config_rootdir / task.src).parent / cmd_path)
+            command = str(task.src.parent / cmd_path)
 
-        # metadata
+        from aiida_shell import ShellCode
+
+        label_uuid = str(uuid.uuid4())
+        # PRCOMMENT aiida-shell created the code before from the command we passed but this only works if it can resolve commands. Since we now want to support environment variables that possibly cannot be resoved until submission (because it uses environment variables in one of the source files)
+        code = ShellCode(
+            label=f"{command}-{label_uuid}",
+            computer=aiida.orm.load_computer(task.computer),
+            filepath_executable=command,
+            default_calc_job_plugin="core.shell",
+            use_double_quotes=True,
+        ).store()
+
         metadata: dict[str, Any] = {}
-        ## Source file
-        env_source_paths = [
-            env_source_path
-            if (env_source_path := Path(env_source_file)).is_absolute()
-            else (task.config_rootdir / env_source_path)
-            for env_source_file in task.env_source_files
-        ]
+        # Files that are sourced before the execution of the script
+        env_source_paths = [Path(env_source_file) for env_source_file in task.env_source_files]
         prepend_text = "\n".join([f"source {env_source_path}" for env_source_path in env_source_paths])
+
         metadata["options"] = {"prepend_text": prepend_text}
         # NOTE: Hardcoded for now, possibly make user-facing option (see issue #159)
         metadata["options"]["use_symlinks"] = True
@@ -262,7 +269,7 @@ class AiidaWorkGraph:
         workgraph_task = self._workgraph.add_task(
             "workgraph.shelljob",
             name=label,
-            command=command,
+            command=code,
             arguments="",
             outputs=[],
             metadata=metadata,
@@ -289,6 +296,7 @@ class AiidaWorkGraph:
             computer=computer,
             filepath_executable=str(task.src),
             with_mpi=False,
+            use_double_quotes=True,
         ).store()
 
         builder = IconCalculation.get_builder()

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -92,9 +92,11 @@ tasks:
   - ROOT:
       # All tasks inherit the root task properties
       host: santis
+      computer: localhost # TODO root task does not pass specs currently, see C2SM/Sirocco/issues/7 
       account: g110
   - extpar:
       plugin: shell  # no extpar plugin available yet
+      computer: localhost
       src: scripts/extpar
       command: "extpar --verbose --input {PORT::obs}"
       uenv:
@@ -104,7 +106,8 @@ tasks:
       walltime: 00:02:00
   - preproc:
       plugin: shell
-      src: scripts/cleanup.sh
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
       command: "cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}"
       env_source_files: data/dummy_source_file.sh
       nodes: 4
@@ -114,14 +117,15 @@ tasks:
         mount_point: runtime/mount/point
   - icon:
       plugin: icon
-      src: ./ICON/bin/icon
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/large/config/ICON/bin/icon
       nodes: 40
       walltime: 23:59:59
       namelists:
-        - ./ICON/icon_master.namelist:
+        - $TEST_ROOTDIR/tests/cases/large/config/ICON/icon_master.namelist:
             master_time_control_nml:
               checkpointtimeintval: 'P2M'
-        - ./ICON/NAMELIST_exclaim_ape_R02B04:
+        - $TEST_ROOTDIR/tests/cases/large/config/ICON/NAMELIST_exclaim_ape_R02B04:
             parallel_nml:
               nproma: 96
             output_nml[1]:
@@ -131,7 +135,8 @@ tasks:
         mount_point: runtime/mount/point
   - postproc_1:
       plugin: shell
-      src: scripts/main_script_ocn.sh
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
       command: "main_script_ocn.sh {PORT::None}"
       nodes: 2
       walltime: 00:05:00
@@ -140,7 +145,8 @@ tasks:
         mount_point: runtime/mount/point
   - postproc_2:
       plugin: shell
-      src: scripts/main_script_atm.sh
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/main_script_atm.sh
       command: "main_script_atm.sh --input {PORT::streams}"
       multi_arg_sep: ","
       nodes: 2
@@ -150,13 +156,15 @@ tasks:
         mount_point: runtime/mount/point
   - store_and_clean_1:
       plugin: shell
-      src: scripts/post_clean.sh
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
       command: "post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}"
       nodes: 1
       walltime: 00:01:00
   - store_and_clean_2:
       plugin: shell
-      src: scripts/post_clean.sh
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
       command: "post_clean.sh --archive {PORT::archive} --clean {PORT::clean}"
       nodes: 1
       walltime: 00:01:00
@@ -164,13 +172,13 @@ data:
   available:
     - grid_file:
         type: file
-        src: data/grid
+        src: $TEST_ROOTDIR/tests/cases/large/config/data/grid
     - obs_data:
         type: file
-        src: data/obs_data
+        src: $TEST_ROOTDIR/tests/cases/large/config/data/obs_data
     - ERA5:
         type: file
-        src: data/era5
+        src: $TEST_ROOTDIR/tests/cases/large/config/data/era5
   generated:
     - extpar_file:
         type: file

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -122,10 +122,10 @@ tasks:
       nodes: 40
       walltime: 23:59:59
       namelists:
-        - $TEST_ROOTDIR/tests/cases/large/config/ICON/icon_master.namelist:
+        - ./ICON/icon_master.namelist:
             master_time_control_nml:
               checkpointtimeintval: 'P2M'
-        - $TEST_ROOTDIR/tests/cases/large/config/ICON/NAMELIST_exclaim_ape_R02B04:
+        - ./ICON/NAMELIST_exclaim_ape_R02B04:
             parallel_nml:
               nproma: 96
             output_nml[1]:

--- a/tests/cases/large/data/config.txt
+++ b/tests/cases/large/data/config.txt
@@ -8,6 +8,7 @@ cycles:
               - extpar_file
             name: 'extpar'
             coordinates: {}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -27,12 +28,13 @@ cycles:
               - icon_input [date: 2025-01-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-01-01 00:00:00]:
@@ -45,6 +47,7 @@ cycles:
               - icon_restart [date: 2025-01-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -58,12 +61,13 @@ cycles:
               - postout_1 [date: 2025-01-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2025-01-01 00:00:00]:
@@ -75,11 +79,12 @@ cycles:
               - stored_data_1 [date: 2025-01-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2025-03-01 00:00:00]:
@@ -93,12 +98,13 @@ cycles:
               - icon_input [date: 2025-03-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-03-01 00:00:00]:
@@ -112,6 +118,7 @@ cycles:
               - icon_restart [date: 2025-03-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -125,12 +132,13 @@ cycles:
               - postout_1 [date: 2025-03-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2025-03-01 00:00:00]:
@@ -142,11 +150,12 @@ cycles:
               - stored_data_1 [date: 2025-03-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2025-05-01 00:00:00]:
@@ -162,12 +171,13 @@ cycles:
               - icon [date: 2025-01-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-05-01 00:00:00]:
@@ -181,6 +191,7 @@ cycles:
               - icon_restart [date: 2025-05-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -194,12 +205,13 @@ cycles:
               - postout_1 [date: 2025-05-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2025-05-01 00:00:00]:
@@ -211,11 +223,12 @@ cycles:
               - stored_data_1 [date: 2025-05-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2025-07-01 00:00:00]:
@@ -231,12 +244,13 @@ cycles:
               - icon [date: 2025-03-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-07-01 00:00:00]:
@@ -250,6 +264,7 @@ cycles:
               - icon_restart [date: 2025-07-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -263,12 +278,13 @@ cycles:
               - postout_1 [date: 2025-07-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2025-07-01 00:00:00]:
@@ -280,11 +296,12 @@ cycles:
               - stored_data_1 [date: 2025-07-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2025-09-01 00:00:00]:
@@ -300,12 +317,13 @@ cycles:
               - icon [date: 2025-05-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-09-01 00:00:00]:
@@ -319,6 +337,7 @@ cycles:
               - icon_restart [date: 2025-09-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -332,12 +351,13 @@ cycles:
               - postout_1 [date: 2025-09-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2025-09-01 00:00:00]:
@@ -349,11 +369,12 @@ cycles:
               - stored_data_1 [date: 2025-09-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2025-11-01 00:00:00]:
@@ -369,12 +390,13 @@ cycles:
               - icon [date: 2025-07-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2025-11-01 00:00:00]:
@@ -388,6 +410,7 @@ cycles:
               - icon_restart [date: 2025-11-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -401,12 +424,13 @@ cycles:
               - postout_1 [date: 2025-11-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2025-11-01 00:00:00]:
@@ -418,11 +442,12 @@ cycles:
               - stored_data_1 [date: 2025-11-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2026-01-01 00:00:00]:
@@ -438,12 +463,13 @@ cycles:
               - icon [date: 2025-09-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-01-01 00:00:00]:
@@ -457,6 +483,7 @@ cycles:
               - icon_restart [date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -470,12 +497,13 @@ cycles:
               - postout_1 [date: 2026-01-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2026-01-01 00:00:00]:
@@ -487,11 +515,12 @@ cycles:
               - stored_data_1 [date: 2026-01-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2026-03-01 00:00:00]:
@@ -507,12 +536,13 @@ cycles:
               - icon [date: 2025-11-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-03-01 00:00:00]:
@@ -526,6 +556,7 @@ cycles:
               - icon_restart [date: 2026-03-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -539,12 +570,13 @@ cycles:
               - postout_1 [date: 2026-03-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2026-03-01 00:00:00]:
@@ -556,11 +588,12 @@ cycles:
               - stored_data_1 [date: 2026-03-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2026-05-01 00:00:00]:
@@ -576,12 +609,13 @@ cycles:
               - icon [date: 2026-01-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-05-01 00:00:00]:
@@ -595,6 +629,7 @@ cycles:
               - icon_restart [date: 2026-05-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -608,12 +643,13 @@ cycles:
               - postout_1 [date: 2026-05-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2026-05-01 00:00:00]:
@@ -625,11 +661,12 @@ cycles:
               - stored_data_1 [date: 2026-05-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2026-07-01 00:00:00]:
@@ -645,12 +682,13 @@ cycles:
               - icon [date: 2026-03-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-07-01 00:00:00]:
@@ -664,6 +702,7 @@ cycles:
               - icon_restart [date: 2026-07-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -677,12 +716,13 @@ cycles:
               - postout_1 [date: 2026-07-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2026-07-01 00:00:00]:
@@ -694,11 +734,12 @@ cycles:
               - stored_data_1 [date: 2026-07-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2026-09-01 00:00:00]:
@@ -714,12 +755,13 @@ cycles:
               - icon [date: 2026-05-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-09-01 00:00:00]:
@@ -733,6 +775,7 @@ cycles:
               - icon_restart [date: 2026-09-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -746,12 +789,13 @@ cycles:
               - postout_1 [date: 2026-09-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2026-09-01 00:00:00]:
@@ -763,11 +807,12 @@ cycles:
               - stored_data_1 [date: 2026-09-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - icon_bimonthly [date: 2026-11-01 00:00:00]:
@@ -783,12 +828,13 @@ cycles:
               - icon [date: 2026-07-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/cleanup.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/cleanup.sh
             command: 'cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}'
             env source files: ['data/dummy_source_file.sh']
         - icon [date: 2026-11-01 00:00:00]:
@@ -802,6 +848,7 @@ cycles:
               - icon_restart [date: 2026-11-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -815,12 +862,13 @@ cycles:
               - postout_1 [date: 2026-11-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_ocn.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/main_script_ocn.sh
             command: 'main_script_ocn.sh {PORT::None}'
             env source files: []
         - store_and_clean_1 [date: 2026-11-01 00:00:00]:
@@ -832,11 +880,12 @@ cycles:
               - stored_data_1 [date: 2026-11-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}'
             env source files: []
   - yearly [date: 2025-01-01 00:00:00]:
@@ -853,12 +902,13 @@ cycles:
               - postout_2 [date: 2025-01-01 00:00:00]
             name: 'postproc_2'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_atm.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/main_script_atm.sh
             command: 'main_script_atm.sh --input {PORT::streams}'
             env source files: []
         - store_and_clean_2 [date: 2025-01-01 00:00:00]:
@@ -874,11 +924,12 @@ cycles:
               - stored_data_2 [date: 2025-01-01 00:00:00]
             name: 'store_and_clean_2'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2026-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh --archive {PORT::archive} --clean {PORT::clean}'
             env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
@@ -895,12 +946,13 @@ cycles:
               - postout_2 [date: 2026-01-01 00:00:00]
             name: 'postproc_2'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/main_script_atm.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/main_script_atm.sh
             command: 'main_script_atm.sh --input {PORT::streams}'
             env source files: []
         - store_and_clean_2 [date: 2026-01-01 00:00:00]:
@@ -916,10 +968,11 @@ cycles:
               - stored_data_2 [date: 2026-01-01 00:00:00]
             name: 'store_and_clean_2'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/post_clean.sh
+            src: $TEST_ROOTDIR/tests/cases/large/config/scripts/scripts/post_clean.sh
             command: 'post_clean.sh --archive {PORT::archive} --clean {PORT::clean}'
             env source files: []

--- a/tests/cases/parameters/config/config.yml
+++ b/tests/cases/parameters/config/config.yml
@@ -56,35 +56,35 @@ cycles:
 tasks:
   - icon:
       plugin: shell
-      # FIXME
-      # Relative path -> except if this cannot be resolved to a registered code
-      # Probably either enforce absolute path, or provide a code argument
-      # See: https://github.com/C2SM/Sirocco/pull/153
-      src: scripts/icon.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
       command: "icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}"
       parameters: [foo, bar]
   - statistics_foo:
       plugin: shell
-      src: scripts/statistics.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
       command: "statistics.py {PORT::None}"
       parameters: [bar]
   - statistics_foo_bar:
       plugin: shell
-      src: scripts/statistics.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
       command: "statistics.py {PORT::None}"
   - merge:
       plugin: shell
-      src: scripts/merge.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/merge.py
       command: "merge.py {PORT::None}"
 
 data:
   available:
     - initial_conditions:
         type: file
-        src: data/initial_conditions
+        src: $TEST_ROOTDIR/tests/cases/parameters/config/data/initial_conditions
     - forcing:
         type: file
-        src: data/forcing
+        src: $TEST_ROOTDIR/tests/cases/parameters/config/data/forcing
   generated:
     - icon_output:
         type: file

--- a/tests/cases/parameters/data/config.txt
+++ b/tests/cases/parameters/data/config.txt
@@ -10,9 +10,10 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2026-01-01 00:00:00]:
@@ -24,9 +25,10 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - statistics_foo [bar: 3.0, date: 2026-01-01 00:00:00]:
@@ -37,9 +39,10 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2026-01-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
         - statistics_foo_bar [date: 2026-01-01 00:00:00]:
@@ -49,9 +52,10 @@ cycles:
               - analysis_foo_bar [date: 2026-01-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
   - bimonthly_tasks [date: 2026-07-01 00:00:00]:
@@ -65,9 +69,10 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2026-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2026-07-01 00:00:00]:
@@ -79,9 +84,10 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2026-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - statistics_foo [bar: 3.0, date: 2026-07-01 00:00:00]:
@@ -92,9 +98,10 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2026-07-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
         - statistics_foo_bar [date: 2026-07-01 00:00:00]:
@@ -104,9 +111,10 @@ cycles:
               - analysis_foo_bar [date: 2026-07-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
   - bimonthly_tasks [date: 2027-01-01 00:00:00]:
@@ -120,9 +128,10 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2027-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2027-01-01 00:00:00]:
@@ -134,9 +143,10 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2027-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - statistics_foo [bar: 3.0, date: 2027-01-01 00:00:00]:
@@ -147,9 +157,10 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2027-01-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
         - statistics_foo_bar [date: 2027-01-01 00:00:00]:
@@ -159,9 +170,10 @@ cycles:
               - analysis_foo_bar [date: 2027-01-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
   - bimonthly_tasks [date: 2027-07-01 00:00:00]:
@@ -175,9 +187,10 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2027-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - icon [foo: 1, bar: 3.0, date: 2027-07-01 00:00:00]:
@@ -189,9 +202,10 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2027-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
             env source files: []
         - statistics_foo [bar: 3.0, date: 2027-07-01 00:00:00]:
@@ -202,9 +216,10 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2027-07-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
         - statistics_foo_bar [date: 2027-07-01 00:00:00]:
@@ -214,9 +229,10 @@ cycles:
               - analysis_foo_bar [date: 2027-07-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/statistics.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/statistics.py
             command: 'statistics.py {PORT::None}'
             env source files: []
   - yearly [date: 2026-01-01 00:00:00]:
@@ -229,9 +245,10 @@ cycles:
               - yearly_analysis [date: 2026-01-01 00:00:00]
             name: 'merge'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/merge.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/merge.py
             command: 'merge.py {PORT::None}'
             env source files: []
   - yearly [date: 2027-01-01 00:00:00]:
@@ -244,8 +261,9 @@ cycles:
               - yearly_analysis [date: 2027-01-01 00:00:00]
             name: 'merge'
             coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
+            computer: 'localhost'
             cycle point: [2027-01-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
-            src: scripts/merge.py
+            src: $TEST_ROOTDIR/tests/cases/parameters/config/scripts/merge.py
             command: 'merge.py {PORT::None}'
             env source files: []

--- a/tests/cases/small-icon/config/ICON/bin/icon
+++ b/tests/cases/small-icon/config/ICON/bin/icon
@@ -1,0 +1,1 @@
+/opt/view/bin/icon

--- a/tests/cases/small-icon/config/config.yml
+++ b/tests/cases/small-icon/config/config.yml
@@ -44,8 +44,8 @@ tasks:
       computer: localhost
       src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/bin/icon
       namelists:
-        - $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/icon_master.namelist
-        - $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/model.namelist
+        - ./ICON/icon_master.namelist
+        - ./ICON/model.namelist
   - cleanup:
       plugin: shell
       computer: localhost

--- a/tests/cases/small-icon/config/config.yml
+++ b/tests/cases/small-icon/config/config.yml
@@ -41,36 +41,37 @@ cycles:
 tasks:
   - icon:
       plugin: icon
-      src: ./ICON/bin/icon
       computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/bin/icon
       namelists:
-        - ./ICON/icon_master.namelist
-        - ./ICON/model.namelist
+        - $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/icon_master.namelist
+        - $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/model.namelist
   - cleanup:
       plugin: shell
-      src: scripts/cleanup.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/small-icon/config/scripts/cleanup.py
       command: "cleanup.py"
 data:
   available:
      - icon_grid_simple:
          type: file
-         src: ICON/icon_grid_simple.nc
+         src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/icon_grid_simple.nc
          computer: localhost
      - ecrad_data:
          type: file
-         src: ICON/ecrad_data
+         src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/ecrad_data
          computer: localhost
      - ECHAM6_CldOptProps:
          type: file
-         src: ICON/ECHAM6_CldOptProps.nc
+         src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/ECHAM6_CldOptProps.nc
          computer: localhost
      - rrtmg_sw:
          type: file
-         src: ICON/rrtmg_sw.nc
+         src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/rrtmg_sw.nc
          computer: localhost
      - dmin_wetgrowth_lookup:
          type: file
-         src: ICON/dmin_wetgrowth_lookup.nc
+         src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/dmin_wetgrowth_lookup.nc
          computer: localhost
   generated:
      - finish:

--- a/tests/cases/small-icon/data/config.txt
+++ b/tests/cases/small-icon/data/config.txt
@@ -62,8 +62,9 @@ cycles:
               - icon [date: 2026-05-01 00:00:00]
             name: 'cleanup'
             coordinates: {}
+            computer: 'localhost'
             cycle point: []
             plugin: 'shell'
-            src: scripts/cleanup.py
+            src: $TEST_ROOTDIR/tests/cases/small-icon/config/scripts/cleanup.py
             command: 'cleanup.py'
             env source files: []

--- a/tests/cases/small-shell/config/config.yml
+++ b/tests/cases/small-shell/config/config.yml
@@ -33,25 +33,25 @@ cycles:
                     date: 2026-05-01T00:00
 tasks:
   - icon:
-      computer: localhost
       plugin: shell
-      src: scripts/icon.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/small-shell/config/scripts/icon.py
       command: "icon.py --restart {PORT::restart} --init {PORT::init}"
-      env_source_files: data/dummy_source_file.sh
+      env_source_files: $TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh
   - cleanup:
-      computer: localhost
       plugin: shell
-      src: scripts/cleanup.py
+      computer: localhost
+      src: $TEST_ROOTDIR/tests/cases/small-shell/config/scripts/cleanup.py
       command: "cleanup.py"
 data:
   available:
      - icon_namelist:
          type: file
-         src: data/input
+         src: $TEST_ROOTDIR/tests/cases/small-shell/config/data/input
      - initial_conditions:
          type: file
          #computer: localhost # TODO requires fix from PR #136
-         src: data/initial_conditions
+         src: $TEST_ROOTDIR/tests/cases/small-shell/config/data/initial_conditions
   generated:
      - icon_output:
          type: file

--- a/tests/cases/small-shell/data/config.txt
+++ b/tests/cases/small-shell/data/config.txt
@@ -13,9 +13,9 @@ cycles:
             computer: 'localhost'
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/small-shell/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
-            env source files: ['data/dummy_source_file.sh']
+            env source files: ['$TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
         - icon [date: 2026-03-01 00:00:00]:
@@ -30,9 +30,9 @@ cycles:
             computer: 'localhost'
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/small-shell/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
-            env source files: ['data/dummy_source_file.sh']
+            env source files: ['$TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
         - icon [date: 2026-05-01 00:00:00]:
@@ -47,9 +47,9 @@ cycles:
             computer: 'localhost'
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
-            src: scripts/icon.py
+            src: $TEST_ROOTDIR/tests/cases/small-shell/config/scripts/icon.py
             command: 'icon.py --restart {PORT::restart} --init {PORT::init}'
-            env source files: ['data/dummy_source_file.sh']
+            env source files: ['$TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
   - lastly:
       tasks:
         - cleanup:
@@ -60,6 +60,6 @@ cycles:
             computer: 'localhost'
             cycle point: []
             plugin: 'shell'
-            src: scripts/cleanup.py
+            src: $TEST_ROOTDIR/tests/cases/small-shell/config/scripts/cleanup.py
             command: 'cleanup.py'
             env source files: []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,29 +189,29 @@ export TEST_ROOTDIR={test_rootdir}
 # Expand environment variables in symlink targets and update them to resolved paths
 
 for link in *; do
-if [ -L "$link" ]; then
-target=$(readlink "$link")
+    if [ -L "$link" ]; then
+        target=$(readlink "$link")
 
-echo "Found symlink: $link -> $target"
+        echo "Found symlink: $link -> $target"
 
-# Only process if target includes a variable
-if [[ "$target" =~ \\$[A-Za-z_][A-Za-z0-9_]* ]]; then
-# Use eval to expand environment variables
-eval "expanded=\\"$target\\""
+        # Only process if target includes a variable
+        if [[ "$target" =~ \\$[A-Za-z_][A-Za-z0-9_]* ]]; then
+            # Use eval to expand environment variables
+            eval "expanded=\\"$target\\""
 
-# Resolve to absolute path
-resolved=$(readlink -f "$expanded")
+            # Resolve to absolute path
+            resolved=$(readlink -f "$expanded")
 
-if [ -e "$resolved" ]; then
-echo " -> Expanding to: $resolved"
-rm "$link"
-ln -s "$resolved" "$link"
-else
-echo " !! Expanded path does not exist: $resolved"
-fi
-else
-echo " -> No environment variable to expand."
-fi
-fi
+            if [ -e "$resolved" ]; then
+                echo " -> Expanding to: $resolved"
+                rm "$link"
+                ln -s "$resolved" "$link"
+            else
+                echo " !! Expanded path does not exist: $resolved"
+            fi
+        else
+            echo " -> No environment variable to expand."
+        fi
+    fi
 done"""
     aiida_localhost.set_prepend_text(prepend_text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 import subprocess
 
@@ -63,7 +64,7 @@ def minimal_config() -> models.ConfigWorkflow:
         name="minimal",
         rootdir=pathlib.Path("minimal"),
         cycles=[models.ConfigCycle(name="minimal", tasks=[models.ConfigCycleTask(name="some_task")])],
-        tasks=[models.ConfigShellTask(name="some_task", command="some_command")],
+        tasks=[models.ConfigShellTask(name="some_task", command="some_command", computer="localhost")],
         data=models.ConfigData(
             available=[
                 models.ConfigAvailableData(name="available", type=models.DataType.FILE, src=pathlib.Path("foo.txt"))
@@ -97,8 +98,8 @@ def minimal_invert_task_io_config() -> models.ConfigWorkflow:
             ),
         ],
         tasks=[
-            models.ConfigShellTask(name="task_a", command="command_a"),
-            models.ConfigShellTask(name="task_b", command="command_b"),
+            models.ConfigShellTask(name="task_a", computer="localhost", command="command_a"),
+            models.ConfigShellTask(name="task_b", computer="localhost", command="command_b"),
         ],
         data=models.ConfigData(
             available=[
@@ -163,6 +164,9 @@ def serialize_nml(config_paths: dict[str, pathlib.Path], workflow: workflow.Work
 
 
 def pytest_configure(config):
+    os.environ["TEST_ROOTDIR"] = f"{config.rootdir}"
+    print(f"Running tests from: {config.rootdir}")  # noqa: T201
+
     if config.getoption("reserialize"):
         LOGGER.info("Regenerating serialized references")
         for config_case in ALL_CONFIG_CASES:
@@ -170,3 +174,44 @@ def pytest_configure(config):
             wf = workflow.Workflow.from_config_file(str(config_paths["yml"]))
             serialize_worklfow(config_paths=config_paths, workflow=wf)
             serialize_nml(config_paths=config_paths, workflow=wf)
+
+
+@pytest.fixture(scope="session")
+def test_rootdir(pytestconfig):
+    """The directory of the project independent from where the tests are started"""
+    return pathlib.Path(pytestconfig.rootdir)
+
+
+@pytest.fixture
+def configure_aiida_localhost(test_rootdir, aiida_localhost):
+    prepend_text = f"""#!/bin/bash
+export TEST_ROOTDIR={test_rootdir}
+# Expand environment variables in symlink targets and update them to resolved paths
+
+for link in *; do
+if [ -L "$link" ]; then
+target=$(readlink "$link")
+
+echo "Found symlink: $link -> $target"
+
+# Only process if target includes a variable
+if [[ "$target" =~ \\$[A-Za-z_][A-Za-z0-9_]* ]]; then
+# Use eval to expand environment variables
+eval "expanded=\\"$target\\""
+
+# Resolve to absolute path
+resolved=$(readlink -f "$expanded")
+
+if [ -e "$resolved" ]; then
+echo " -> Expanding to: $resolved"
+rm "$link"
+ln -s "$resolved" "$link"
+else
+echo " !! Expanded path does not exist: $resolved"
+fi
+else
+echo " -> No environment variable to expand."
+fi
+fi
+done"""
+    aiida_localhost.set_prepend_text(prepend_text)

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -56,7 +56,7 @@ def test_run_workgraph(config_paths):
 
 
 @pytest.mark.requires_icon
-@pytest.mark.usefixtures("config_case", "aiida_localhost")
+@pytest.mark.usefixtures("config_case", "configure_aiida_localhost")
 @pytest.mark.parametrize(
     "config_case",
     [

--- a/tests/unit_tests/parsing/test_yaml_data_models.py
+++ b/tests/unit_tests/parsing/test_yaml_data_models.py
@@ -33,6 +33,7 @@ def minimal_config_path(tmp_path):
         tasks:
           - b:
               plugin: shell
+              computer: localhost
               command: some_command
         data:
           available:


### PR DESCRIPTION
Everywhere instead of GeneratedData. In AvailableData I also did not add it since we require #136 to be merged before we can use `RemoteData` in shell tasks. I consequently added it as TODO.

To make it clear to the user that the scripts and icon executable are on a computer, I made computer a required argument (I would like to do the same for data but need #136). However, in the parsing process we do not have a mechanism to pass default arguments from the root task to the other tasks so I need to add everywhere `computer`. Since the root task feature is not essential for a minimum, I marked this with a TODO referencing one of the issues about root.

When defining an icon task in the config yml, it is a bit opaque that the computer is not applied on the namelists but only on the executable path (`src`). Bundling the computer and the executable path to a subsection is not a solution since we want to also pass submission information over the computer that can be overwritten on the same indentation level. I therefore only allow relative paths for namelists to make clear that they are an exception.

I realized a design flaw in the usage of environment variables. I wanted to use environment variables to use absolute paths without hardcoding the repos directory (as this is different for every dev/CI). The resolvement of the environment variables should mainly happen during the running time of the workflow since the environment variables could be specified on a remote machine. Now aiida does not resolve the environment variables when linking them to the aiida working directory (I don't know if there is a way but since this logic it is not trivial to fix), so the environment variable is escaped. There needs to be a step that resolves the escaped environment variables. Right now I add a script that does this as prepend text to the computer (see conftest.py in PR 153). I think we need the environment variables when we start to use the CSCS CI as we might want to run the same workflow but with a different grid or namelist parameter. It is hard to say for sure now if it is really needed for the CSCS CI, since we could make another dedicated use case for this, but it might be needed.