### PR TITLE
Improve error handling when secrets are not accessible (from fork)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -20,6 +20,11 @@ jobs:
       packages: write
 
     steps:
+    - name: Check access to GitHub secrets
+      run: echo "Pull request that trigger this workflow need to be on upstream repo to access GitHub secrets."; exit 1
+      # if a pull request is merged from a fork
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+
     - uses: actions/checkout@v4
 
     - name: Set up Spack


### PR DESCRIPTION
This should just demo the functionality of PR https://github.com/C2SM/Sirocco/pull/156 . It will fail because it does not have access to the secret but with a meaningful error message.