### PR TITLE
Require `computer` for available data and remove `type`

### DIFF
--- a/src/sirocco/core/graph_items.py
+++ b/src/sirocco/core/graph_items.py
@@ -52,10 +52,13 @@ class Data(ConfigBaseDataSpecs, GraphItem):
         return data_class(coordinates=coordinates, **config_kwargs)
 
 
+@dataclass(kw_only=True)
 class AvailableData(Data):
     src: Path
+    computer: str
 
 
+@dataclass(kw_only=True)
 class GeneratedData(Data):
     pass
 

--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import itertools
 import re
 import time
@@ -486,17 +485,10 @@ class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
         return nmls
 
 
-class DataType(enum.StrEnum):
-    FILE = enum.auto()
-    DIR = enum.auto()
-
-
 @dataclass(kw_only=True)
 class ConfigBaseDataSpecs:
-    type: DataType
     src: Path | None = None
     format: str | None = None
-    computer: str | None = None
 
 
 class ConfigBaseData(_NamedBaseModel, ConfigBaseDataSpecs):
@@ -511,18 +503,17 @@ class ConfigBaseData(_NamedBaseModel, ConfigBaseDataSpecs):
             >>> snippet = textwrap.dedent(
             ...     '''
             ...       foo:
-            ...         type: "file"
             ...         src: "foo.txt"
             ...     '''
             ... )
             >>> validate_yaml_content(ConfigBaseData, snippet)
-            ConfigBaseData(type=<DataType.FILE: 'file'>, src=PosixPath('foo.txt'), format=None, computer=None, name='foo', parameters=[])
+            ConfigBaseData(src=PosixPath('foo.txt'), format=None, name='foo', parameters=[])
 
 
         from python:
 
-            >>> ConfigBaseData(name="foo", type=DataType.FILE, src="foo.txt")
-            ConfigBaseData(type=<DataType.FILE: 'file'>, src=PosixPath('foo.txt'), format=None, computer=None, name='foo', parameters=[])
+            >>> ConfigBaseData(name="foo", src="foo.txt")
+            ConfigBaseData(src=PosixPath('foo.txt'), format=None, name='foo', parameters=[])
     """
 
     parameters: list[str] = []
@@ -530,16 +521,10 @@ class ConfigBaseData(_NamedBaseModel, ConfigBaseDataSpecs):
 
 class ConfigAvailableData(ConfigBaseData):
     src: Path
+    computer: str
 
 
-class ConfigGeneratedData(ConfigBaseData):
-    @field_validator("computer")
-    @classmethod
-    def invalid_field(cls, value: str | None) -> str | None:
-        if value is not None:
-            msg = "The field 'computer' can only be specified for available data."
-            raise ValueError(msg)
-        return value
+class ConfigGeneratedData(ConfigBaseData): ...
 
 
 class ConfigData(BaseModel):
@@ -555,11 +540,10 @@ class ConfigData(BaseModel):
             ...     '''
             ...     available:
             ...       - foo:
-            ...           type: "file"
+            ...           computer: "localhost"
             ...           src: "foo.txt"
             ...     generated:
             ...       - bar:
-            ...           type: "file"
             ...           src: "bar.txt"
             ...     '''
             ... )
@@ -639,11 +623,10 @@ class ConfigWorkflow(BaseModel):
             ...     data:
             ...       available:
             ...         - foo:
-            ...             type: file
+            ...             computer: localhost
             ...             src: foo.txt
             ...       generated:
             ...         - bar:
-            ...             type: dir
             ...             src: bar
             ...     '''
             ... )
@@ -666,11 +649,13 @@ class ConfigWorkflow(BaseModel):
             ...     ],
             ...     data=ConfigData(
             ...         available=[
-            ...             ConfigAvailableData(name="foo", type=DataType.FILE, src="foo.txt")
+            ...             ConfigAvailableData(
+            ...                 name="foo",
+            ...                 computer="localhost",
+            ...                 src="foo.txt",
+            ...             )
             ...         ],
-            ...         generated=[
-            ...             ConfigGeneratedData(name="bar", type=DataType.DIR, src="bar")
-            ...         ],
+            ...         generated=[ConfigGeneratedData(name="bar", src="bar")],
             ...     ),
             ...     parameters={},
             ... )

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import io
-import os
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
@@ -190,24 +189,14 @@ class AiidaWorkGraph:
         """
         label = self.get_aiida_label_from_graph_item(data)
 
-        if data.computer is not None:
-            try:
-                computer = aiida.orm.load_computer(data.computer)
-            except NotExistent as err:
-                msg = f"Could not find computer {data.computer!r} for input {data}."
-                raise ValueError(msg) from err
-            # `remote_path` must be str not PosixPath to be JSON-serializable
-            # FIXME: should not use resolved relative path, will be fixed in PR #153
-            self._aiida_data_nodes[label] = aiida.orm.RemoteData(
-                remote_path=str(data.src), label=label, computer=computer
-            )
-        elif data.computer is None and data.type == "file":
-            self._aiida_data_nodes[label] = aiida.orm.SinglefileData(label=label, file=os.path.expandvars(data.src))
-        elif data.computer is None and data.type == "dir":
-            self._aiida_data_nodes[label] = aiida.orm.FolderData(label=label, tree=os.path.expandvars(data.src))
-        else:
-            msg = f"Data type {data.type!r} not supported. Please use 'file' or 'dir'."
-            raise ValueError(msg)
+        try:
+            computer = aiida.orm.load_computer(data.computer)
+        except NotExistent as err:
+            msg = f"Could not find computer {data.computer!r} for input {data}."
+            raise ValueError(msg) from err
+        # `remote_path` must be str not PosixPath to be JSON-serializable
+        # FIXME: should not use resolved relative path, will be fixed in PR #153
+        self._aiida_data_nodes[label] = aiida.orm.RemoteData(remote_path=str(data.src), label=label, computer=computer)
 
     @functools.singledispatchmethod
     def create_task_node(self, task: core.Task):
@@ -425,7 +414,7 @@ class AiidaWorkGraph:
         for input_ in task.input_data_nodes():
             input_label = self.get_aiida_label_from_graph_item(input_)
 
-            if task.computer and input_.computer and isinstance(input_, core.AvailableData):
+            if task.computer and isinstance(input_, core.AvailableData) and input_.computer:
                 # For RemoteData on the same computer, use just the filename
                 filename = input_.src.name
                 filenames[input_.name] = filename

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -171,40 +171,31 @@ tasks:
 data:
   available:
     - grid_file:
-        type: file
+        computer: localhost
         src: $TEST_ROOTDIR/tests/cases/large/config/data/grid
     - obs_data:
-        type: file
+        computer: localhost
         src: $TEST_ROOTDIR/tests/cases/large/config/data/obs_data
     - ERA5:
-        type: file
+        computer: localhost
         src: $TEST_ROOTDIR/tests/cases/large/config/data/era5
   generated:
     - extpar_file:
-        type: file
         src: output
     - icon_input:
-        type: file
         src: output
     - icon_restart:
-        type: file
         format: ncdf
         src: restart
     - stream_1:
-        type: file
         src: output_1
     - stream_2:
-        type: file
         src: output_2
     - postout_1:
-        type: file
         src: postout
     - postout_2:
-        type: file
         src: postout
     - stored_data_1:
-        type: file
         src: stored_data
     - stored_data_2:
-        type: file
         src: stored_data

--- a/tests/cases/parameters/config/config.yml
+++ b/tests/cases/parameters/config/config.yml
@@ -80,29 +80,24 @@ tasks:
 data:
   available:
     - initial_conditions:
-        type: file
+        computer: localhost
         src: $TEST_ROOTDIR/tests/cases/parameters/config/data/initial_conditions
     - forcing:
-        type: file
+        computer: localhost
         src: $TEST_ROOTDIR/tests/cases/parameters/config/data/forcing
   generated:
     - icon_output:
-        type: file
         src: icon_output
         parameters: [foo, bar]
     - icon_restart:
-        type: file
         src: restart
         parameters: [foo, bar]
     - analysis_foo:
-        type: file
         src: analysis
         parameters: [bar]
     - analysis_foo_bar:
-        type: file
         src: analysis
     - yearly_analysis:
-        type: file
         src: analysis
 
 parameters:

--- a/tests/cases/small-shell/config/config.yml
+++ b/tests/cases/small-shell/config/config.yml
@@ -46,16 +46,13 @@ tasks:
 data:
   available:
      - icon_namelist:
-         type: file
+         computer: localhost
          src: $TEST_ROOTDIR/tests/cases/small-shell/config/data/input
      - initial_conditions:
-         type: file
-         #computer: localhost # TODO requires fix from PR #136
+         computer: localhost
          src: $TEST_ROOTDIR/tests/cases/small-shell/config/data/initial_conditions
   generated:
      - icon_output:
-         type: file
          src: icon_output
      - icon_restart:
-         type: file
          src: restart

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,10 +66,8 @@ def minimal_config() -> models.ConfigWorkflow:
         cycles=[models.ConfigCycle(name="minimal", tasks=[models.ConfigCycleTask(name="some_task")])],
         tasks=[models.ConfigShellTask(name="some_task", command="some_command", computer="localhost")],
         data=models.ConfigData(
-            available=[
-                models.ConfigAvailableData(name="available", type=models.DataType.FILE, src=pathlib.Path("foo.txt"))
-            ],
-            generated=[models.ConfigGeneratedData(name="bar", type=models.DataType.DIR, src=pathlib.Path("bar"))],
+            available=[models.ConfigAvailableData(name="available", computer="localhost", src=pathlib.Path("foo.txt"))],
+            generated=[models.ConfigGeneratedData(name="bar", src=pathlib.Path("bar"))],
         ),
         parameters={},
     )
@@ -102,12 +100,10 @@ def minimal_invert_task_io_config() -> models.ConfigWorkflow:
             models.ConfigShellTask(name="task_b", computer="localhost", command="command_b"),
         ],
         data=models.ConfigData(
-            available=[
-                models.ConfigAvailableData(name="available", type=models.DataType.FILE, src=pathlib.Path("foo.txt"))
-            ],
+            available=[models.ConfigAvailableData(name="available", computer="localhost", src=pathlib.Path("foo.txt"))],
             generated=[
-                models.ConfigGeneratedData(name="output_a", type=models.DataType.DIR, src=pathlib.Path("bar")),
-                models.ConfigGeneratedData(name="output_b", type=models.DataType.DIR, src=pathlib.Path("bar")),
+                models.ConfigGeneratedData(name="output_a", src=pathlib.Path("bar")),
+                models.ConfigGeneratedData(name="output_b", src=pathlib.Path("bar")),
             ],
         ),
         parameters={},

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -32,8 +32,7 @@ def test_icon():
 
 # configs that are tested for running workgraph
 @pytest.mark.slow
-@pytest.mark.usefixtures("aiida_localhost")
-@pytest.mark.usefixtures("config_case")
+@pytest.mark.usefixtures("config_case", "configure_aiida_localhost")
 @pytest.mark.parametrize(
     "config_case",
     [

--- a/tests/unit_tests/parsing/test_yaml_data_models.py
+++ b/tests/unit_tests/parsing/test_yaml_data_models.py
@@ -1,25 +1,12 @@
 import textwrap
 
 import pytest
-from pydantic import ValidationError
 
 from sirocco.parsing import yaml_data_models as models
 
 
-@pytest.mark.parametrize("data_type", ["file", "dir"])
-def test_base_data(data_type):
-    testee = models.ConfigBaseData(name="name", type=data_type, src="foo.txt", format=None)
-
-    assert testee.type == data_type
-
-
-@pytest.mark.parametrize("data_type", [None, "invalid", 1.42])
-def test_base_data_invalid_type(data_type):
-    with pytest.raises(ValidationError):
-        _ = models.ConfigBaseData(name="name", src="foo", format="nml")
-
-    with pytest.raises(ValidationError):
-        _ = models.ConfigBaseData(name="name", type=data_type, src="foo", format="nml")
+def test_base_data():
+    models.ConfigBaseData(name="name", src="foo.txt", format=None)
 
 
 @pytest.fixture
@@ -38,11 +25,10 @@ def minimal_config_path(tmp_path):
         data:
           available:
             - c:
-                type: "file"
+                computer: "localhost"
                 src: "c.txt"
           generated:
             - d:
-                type: "dir"
                 src: "d"
         """
     )


### PR DESCRIPTION
With the support of `aiida.orm.RemoteData` we can remove the `type` specification for data as both is supported. For a config file that is more transparent about where the data is located we require to specify the `computer`.