### PR TITLE
Rename `IconTask.src` to `IconTask.bin`

### DIFF
--- a/src/sirocco/parsing/yaml_data_models.py
+++ b/src/sirocco/parsing/yaml_data_models.py
@@ -442,7 +442,7 @@ class ConfigNamelistFile(BaseModel, ConfigNamelistFileSpec):
 @dataclass(kw_only=True)
 class ConfigIconTaskSpecs:
     plugin: ClassVar[Literal["icon"]] = "icon"
-    src: Path = field(repr=False)
+    bin: Path = field(repr=False)
 
 
 class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
@@ -463,7 +463,7 @@ class ConfigIconTask(ConfigBaseTask, ConfigIconTaskSpecs):
         ...           - path/to/case_nml:
         ...               block_1:
         ...                 param_name: param_value
-        ...         src: path/to/icon
+        ...         bin: path/to/icon
         ...     '''
         ... )
         >>> icon_task_cfg = validate_yaml_content(ConfigIconTask, snippet)

--- a/src/sirocco/workgraph.py
+++ b/src/sirocco/workgraph.py
@@ -291,7 +291,7 @@ class AiidaWorkGraph:
             description="aiida_icon",
             default_calc_job_plugin="icon.icon",
             computer=computer,
-            filepath_executable=str(task.src),
+            filepath_executable=str(task.bin),
             with_mpi=False,
             use_double_quotes=True,
         ).store()

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -118,7 +118,7 @@ tasks:
   - icon:
       plugin: icon
       computer: localhost
-      src: $TEST_ROOTDIR/tests/cases/large/config/ICON/bin/icon
+      bin: $TEST_ROOTDIR/tests/cases/large/config/ICON/bin/icon
       nodes: 40
       walltime: 23:59:59
       namelists:

--- a/tests/cases/small-icon/config/config.yml
+++ b/tests/cases/small-icon/config/config.yml
@@ -42,7 +42,7 @@ tasks:
   - icon:
       plugin: icon
       computer: localhost
-      src: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/bin/icon
+      bin: $TEST_ROOTDIR/tests/cases/small-icon/config/ICON/bin/icon
       namelists:
         - ./ICON/icon_master.namelist
         - ./ICON/model.namelist


### PR DESCRIPTION
Since `ShellTask.src` is enforced to be relative by PR #172 while `IconTask.src` to be absolute, the field is renamed to `IconTask.bin` to better distinguish it.