### PR TITLE
Fix `--reserialize` option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,7 @@ def pytest_configure(config):
         for config_case in ALL_CONFIG_CASES:
             config_paths = generate_config_paths(config_case)
             for key, value in config_paths.items():
-                config_paths[key] = config.rootdir / value
+                config_paths[key] = pathlib.Path(config.rootdir) / value
             wf = workflow.Workflow.from_config_file(str(config_paths["yml"]))
             serialize_worklfow(config_paths=config_paths, workflow=wf)
             serialize_nml(config_paths=config_paths, workflow=wf)


### PR DESCRIPTION
The PR #171 (commit 0fef2d8e) introduced a last minute a change to make the reserialization be independent of the path it is executed from by passing `config.rootdir`. However `config.rootdir` is a `LocalPath` that does not work with the rest of the infrastructure without additional changes so we convert it to a `pathlib.Path`.j