### PR TITLE
Add option to pass the remote computer label to tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       env:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
-        hatch -- test -m "not requires_icon" --cover --parallel --remote --localhost-ssh
+        hatch -- test -m "not requires_icon" --cover --parallel --remote localhost-ssh
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       env:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
-        hatch test -m "not requires_icon" --parallel --cover
+        hatch -- test -m "not requires_icon" --cover --parallel --remote --localhost-ssh
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,20 @@ jobs:
         pip install hatch
     - name: Install Graphviz
       run: sudo apt-get install graphviz graphviz-dev
+    - name: Set up SSH on localhost
+      run: |
+        # Start SSH daemon
+        sudo systemctl start ssh
+
+        ssh-keygen -q -t rsa -b 4096 -N "" -f "${HOME}/.ssh/id_rsa"
+        ssh-keygen -y -f "${HOME}/.ssh/id_rsa" >> "${HOME}/.ssh/authorized_keys"
+        ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
+
+        # The permissions on the GitHub runner are 777 which will cause SSH to refuse the keys and cause authentication to fail
+        chmod 755 "${HOME}"
+
+        # Test SSH connection
+        ssh -o StrictHostKeyChecking=no localhost 'echo "SSH connection successful"'
     - name: Install package
       run: |
         pip install .
@@ -38,7 +52,7 @@ jobs:
       env:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
-        hatch -- test -m "not requires_icon" --cover --parallel --remote localhost-ssh
+        hatch test --cover --parallel -- -m "not requires_icon"  --remote localhost-ssh
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
       env:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
-        hatch test --cover --parallel -- -m "not requires_icon"  --remote localhost-ssh
+        hatch test --cover --parallel -- -m "not requires_icon" --remote localhost-ssh
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -77,4 +77,4 @@ jobs:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
         spack env activate .
-        hatch test -m "requires_icon" --parallel tests
+        hatch test --cover --parallel -- -m "requires_icon" --remote localhost-ssh

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -77,4 +77,4 @@ jobs:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
         spack env activate .
-        hatch test --cover --parallel -- -m "requires_icon" --remote localhost-ssh
+        hatch test --cover --parallel -- -m "requires_icon" --remote localhost-ssh tests

--- a/tests/cases/large/config/config.yml
+++ b/tests/cases/large/config/config.yml
@@ -92,11 +92,11 @@ tasks:
   - ROOT:
       # All tasks inherit the root task properties
       host: santis
-      computer: localhost # TODO root task does not pass specs currently, see C2SM/Sirocco/issues/7 
+      computer: remote # TODO root task does not pass specs currently, see C2SM/Sirocco/issues/7
       account: g110
   - extpar:
       plugin: shell  # no extpar plugin available yet
-      computer: localhost
+      computer: remote
       src: scripts/extpar
       command: "extpar --verbose --input {PORT::obs}"
       uenv:
@@ -106,7 +106,7 @@ tasks:
       walltime: 00:02:00
   - preproc:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/cleanup.sh
       command: "bash cleanup.sh -p {PORT::extpar} -e {PORT::era} {PORT::grid}"
       env_source_files: data/dummy_source_file.sh
@@ -117,7 +117,7 @@ tasks:
         mount_point: runtime/mount/point
   - icon:
       plugin: icon
-      computer: localhost
+      computer: remote
       bin: /TESTS_ROOTDIR/tests/cases/large/config/ICON/bin/icon
       nodes: 40
       walltime: 23:59:59
@@ -135,7 +135,7 @@ tasks:
         mount_point: runtime/mount/point
   - postproc_1:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/main_script_ocn.sh
       command: "bash main_script_ocn.sh {PORT::None}"
       nodes: 2
@@ -145,7 +145,7 @@ tasks:
         mount_point: runtime/mount/point
   - postproc_2:
       plugin: shell
-      computer: localhost
+      computer: remote
       command: "bash main_script_atm.sh --input {PORT::streams}"
       multi_arg_sep: ","
       nodes: 2
@@ -155,14 +155,14 @@ tasks:
         mount_point: runtime/mount/point
   - store_and_clean_1:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/post_clean.sh
       command: "bash post_clean.sh {PORT::postout} {PORT::streams} {PORT::icon_input}"
       nodes: 1
       walltime: 00:01:00
   - store_and_clean_2:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/post_clean.sh
       command: "bash post_clean.sh --archive {PORT::archive} --clean {PORT::clean}"
       nodes: 1
@@ -170,13 +170,13 @@ tasks:
 data:
   available:
     - grid_file:
-        computer: localhost
+        computer: remote
         src: /TESTS_ROOTDIR/tests/cases/large/config/data/grid
     - obs_data:
-        computer: localhost
+        computer: remote
         src: /TESTS_ROOTDIR/tests/cases/large/config/data/obs_data
     - ERA5:
-        computer: localhost
+        computer: remote
         src: /TESTS_ROOTDIR/tests/cases/large/config/data/era5
   generated:
     - extpar_file:

--- a/tests/cases/large/data/config.txt
+++ b/tests/cases/large/data/config.txt
@@ -8,7 +8,7 @@ cycles:
               - extpar_file
             name: 'extpar'
             coordinates: {}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -27,7 +27,7 @@ cycles:
               - icon_input [date: 2025-01-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -45,7 +45,7 @@ cycles:
               - icon_restart [date: 2025-01-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -59,7 +59,7 @@ cycles:
               - postout_1 [date: 2025-01-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -76,7 +76,7 @@ cycles:
               - stored_data_1 [date: 2025-01-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2025-03-01 00:00:00]
@@ -94,7 +94,7 @@ cycles:
               - icon_input [date: 2025-03-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -113,7 +113,7 @@ cycles:
               - icon_restart [date: 2025-03-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -127,7 +127,7 @@ cycles:
               - postout_1 [date: 2025-03-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -144,7 +144,7 @@ cycles:
               - stored_data_1 [date: 2025-03-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-03-01 00:00:00 -- 2025-05-01 00:00:00]
@@ -164,7 +164,7 @@ cycles:
               - icon [date: 2025-01-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -183,7 +183,7 @@ cycles:
               - icon_restart [date: 2025-05-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -197,7 +197,7 @@ cycles:
               - postout_1 [date: 2025-05-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -214,7 +214,7 @@ cycles:
               - stored_data_1 [date: 2025-05-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-05-01 00:00:00 -- 2025-07-01 00:00:00]
@@ -234,7 +234,7 @@ cycles:
               - icon [date: 2025-03-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -253,7 +253,7 @@ cycles:
               - icon_restart [date: 2025-07-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -267,7 +267,7 @@ cycles:
               - postout_1 [date: 2025-07-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -284,7 +284,7 @@ cycles:
               - stored_data_1 [date: 2025-07-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-07-01 00:00:00 -- 2025-09-01 00:00:00]
@@ -304,7 +304,7 @@ cycles:
               - icon [date: 2025-05-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -323,7 +323,7 @@ cycles:
               - icon_restart [date: 2025-09-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -337,7 +337,7 @@ cycles:
               - postout_1 [date: 2025-09-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -354,7 +354,7 @@ cycles:
               - stored_data_1 [date: 2025-09-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-09-01 00:00:00 -- 2025-11-01 00:00:00]
@@ -374,7 +374,7 @@ cycles:
               - icon [date: 2025-07-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -393,7 +393,7 @@ cycles:
               - icon_restart [date: 2025-11-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -407,7 +407,7 @@ cycles:
               - postout_1 [date: 2025-11-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -424,7 +424,7 @@ cycles:
               - stored_data_1 [date: 2025-11-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2025, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-11-01 00:00:00 -- 2026-01-01 00:00:00]
@@ -444,7 +444,7 @@ cycles:
               - icon [date: 2025-09-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -463,7 +463,7 @@ cycles:
               - icon_restart [date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -477,7 +477,7 @@ cycles:
               - postout_1 [date: 2026-01-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -494,7 +494,7 @@ cycles:
               - stored_data_1 [date: 2026-01-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
@@ -514,7 +514,7 @@ cycles:
               - icon [date: 2025-11-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -533,7 +533,7 @@ cycles:
               - icon_restart [date: 2026-03-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -547,7 +547,7 @@ cycles:
               - postout_1 [date: 2026-03-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -564,7 +564,7 @@ cycles:
               - stored_data_1 [date: 2026-03-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
@@ -584,7 +584,7 @@ cycles:
               - icon [date: 2026-01-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -603,7 +603,7 @@ cycles:
               - icon_restart [date: 2026-05-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -617,7 +617,7 @@ cycles:
               - postout_1 [date: 2026-05-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -634,7 +634,7 @@ cycles:
               - stored_data_1 [date: 2026-05-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-05-01 00:00:00 -- 2026-07-01 00:00:00]
@@ -654,7 +654,7 @@ cycles:
               - icon [date: 2026-03-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -673,7 +673,7 @@ cycles:
               - icon_restart [date: 2026-07-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -687,7 +687,7 @@ cycles:
               - postout_1 [date: 2026-07-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -704,7 +704,7 @@ cycles:
               - stored_data_1 [date: 2026-07-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-07-01 00:00:00 -- 2026-09-01 00:00:00]
@@ -724,7 +724,7 @@ cycles:
               - icon [date: 2026-05-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -743,7 +743,7 @@ cycles:
               - icon_restart [date: 2026-09-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -757,7 +757,7 @@ cycles:
               - postout_1 [date: 2026-09-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -774,7 +774,7 @@ cycles:
               - stored_data_1 [date: 2026-09-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 9, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-09-01 00:00:00 -- 2026-11-01 00:00:00]
@@ -794,7 +794,7 @@ cycles:
               - icon [date: 2026-07-01 00:00:00]
             name: 'preproc'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 4
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=2, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -813,7 +813,7 @@ cycles:
               - icon_restart [date: 2026-11-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 40
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=23, tm_min=59, tm_sec=59, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -827,7 +827,7 @@ cycles:
               - postout_1 [date: 2026-11-01 00:00:00]
             name: 'postproc_1'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -844,7 +844,7 @@ cycles:
               - stored_data_1 [date: 2026-11-01 00:00:00]
             name: 'store_and_clean_1'
             coordinates: {'date': datetime.datetime(2026, 11, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-11-01 00:00:00 -- 2027-01-01 00:00:00]
@@ -865,7 +865,7 @@ cycles:
               - postout_2 [date: 2025-01-01 00:00:00]
             name: 'postproc_2'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -886,7 +886,7 @@ cycles:
               - stored_data_2 [date: 2025-01-01 00:00:00]
             name: 'store_and_clean_2'
             coordinates: {'date': datetime.datetime(2025, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2025-01-01 00:00:00 -- 2026-01-01 00:00:00]
@@ -907,7 +907,7 @@ cycles:
               - postout_2 [date: 2026-01-01 00:00:00]
             name: 'postproc_2'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             uenv: {'squashfs': 'path/to/squashfs', 'mount_point': 'runtime/mount/point'}
             nodes: 2
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=5, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
@@ -928,7 +928,7 @@ cycles:
               - stored_data_2 [date: 2026-01-01 00:00:00]
             name: 'store_and_clean_2'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             nodes: 1
             walltime: time.struct_time(tm_year=1900, tm_mon=1, tm_mday=1, tm_hour=0, tm_min=1, tm_sec=0, tm_wday=0, tm_yday=1, tm_isdst=-1)
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]

--- a/tests/cases/parameters/config/config.yml
+++ b/tests/cases/parameters/config/config.yml
@@ -56,34 +56,34 @@ cycles:
 tasks:
   - icon:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/icon.py
       command: "python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}"
       parameters: [foo, bar]
   - statistics_foo:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/statistics.py
       command: "python statistics.py {PORT::None}"
       parameters: [bar]
   - statistics_foo_bar:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/statistics.py
       command: "python statistics.py {PORT::None}"
   - merge:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/merge.py
       command: "python merge.py {PORT::None}"
 
 data:
   available:
     - initial_conditions:
-        computer: localhost
+        computer: remote
         src: /TESTS_ROOTDIR/tests/cases/parameters/config/data/initial_conditions
     - forcing:
-        computer: localhost
+        computer: remote
         src: /TESTS_ROOTDIR/tests/cases/parameters/config/data/forcing
   generated:
     - icon_output:

--- a/tests/cases/parameters/data/config.txt
+++ b/tests/cases/parameters/data/config.txt
@@ -10,7 +10,7 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -24,7 +24,7 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -37,7 +37,7 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2026-01-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -49,7 +49,7 @@ cycles:
               - analysis_foo_bar [date: 2026-01-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2026-07-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -65,7 +65,7 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2026-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -79,7 +79,7 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2026-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -92,7 +92,7 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2026-07-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -104,7 +104,7 @@ cycles:
               - analysis_foo_bar [date: 2026-07-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2026, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-07-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -120,7 +120,7 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2027-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -134,7 +134,7 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2027-01-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -147,7 +147,7 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2027-01-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2027, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -159,7 +159,7 @@ cycles:
               - analysis_foo_bar [date: 2027-01-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-01-01 00:00:00 -- 2027-07-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -175,7 +175,7 @@ cycles:
               - icon_restart [foo: 0, bar: 3.0, date: 2027-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 0, 'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -189,7 +189,7 @@ cycles:
               - icon_restart [foo: 1, bar: 3.0, date: 2027-07-01 00:00:00]
             name: 'icon'
             coordinates: {'foo': 1, 'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init} --forcing {PORT::forcing}'
@@ -202,7 +202,7 @@ cycles:
               - analysis_foo [bar: 3.0, date: 2027-07-01 00:00:00]
             name: 'statistics_foo'
             coordinates: {'bar': 3.0, 'date': datetime.datetime(2027, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -214,7 +214,7 @@ cycles:
               - analysis_foo_bar [date: 2027-07-01 00:00:00]
             name: 'statistics_foo_bar'
             coordinates: {'date': datetime.datetime(2027, 7, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-07-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
             command: 'python statistics.py {PORT::None}'
@@ -229,7 +229,7 @@ cycles:
               - yearly_analysis [date: 2026-01-01 00:00:00]
             name: 'merge'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2027-01-01 00:00:00]
             plugin: 'shell'
             command: 'python merge.py {PORT::None}'
@@ -244,7 +244,7 @@ cycles:
               - yearly_analysis [date: 2027-01-01 00:00:00]
             name: 'merge'
             coordinates: {'date': datetime.datetime(2027, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2027-01-01 00:00:00 -- 2028-01-01 00:00:00]
             plugin: 'shell'
             command: 'python merge.py {PORT::None}'

--- a/tests/cases/small-icon/config/config.yml
+++ b/tests/cases/small-icon/config/config.yml
@@ -41,14 +41,14 @@ cycles:
 tasks:
   - icon:
       plugin: icon
-      computer: localhost
+      computer: remote
       bin: /TESTS_ROOTDIR/tests/cases/small-icon/config/ICON/bin/icon
       namelists:
         - ./ICON/icon_master.namelist
         - ./ICON/model.namelist
   - cleanup:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/cleanup.py
       command: "python cleanup.py"
 data:
@@ -56,23 +56,23 @@ data:
      - icon_grid_simple:
          type: file
          src: /TESTS_ROOTDIR/tests/cases/small-icon/config/ICON/icon_grid_simple.nc
-         computer: localhost_ssh
+         computer: remote
      - ecrad_data:
          type: file
          src: /TESTS_ROOTDIR/tests/cases/small-icon/config/ICON/ecrad_data
-         computer: localhost_ssh
+         computer: remote
      - ECHAM6_CldOptProps:
          type: file
          src: /TESTS_ROOTDIR/tests/cases/small-icon/config/ICON/ECHAM6_CldOptProps.nc
-         computer: localhost_ssh
+         computer: remote
      - rrtmg_sw:
          type: file
          src: /TESTS_ROOTDIR/tests/cases/small-icon/config/ICON/rrtmg_sw.nc
-         computer: localhost_ssh
+         computer: remote
      - dmin_wetgrowth_lookup:
          type: file
          src: /TESTS_ROOTDIR/tests/cases/small-icon/config/ICON/dmin_wetgrowth_lookup.nc
-         computer: localhost_ssh
+         computer: remote
   generated:
      - finish:
          type: file

--- a/tests/cases/small-icon/data/config.txt
+++ b/tests/cases/small-icon/data/config.txt
@@ -13,7 +13,7 @@ cycles:
               - restart [date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'icon'
             namelists: [NamelistFile(name='icon_master.namelist'), NamelistFile(name='model.namelist')]
@@ -32,7 +32,7 @@ cycles:
               - restart [date: 2026-03-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'icon'
             namelists: [NamelistFile(name='icon_master.namelist'), NamelistFile(name='model.namelist')]
@@ -51,7 +51,7 @@ cycles:
               - restart [date: 2026-05-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'icon'
             namelists: [NamelistFile(name='icon_master.namelist'), NamelistFile(name='model.namelist')]
@@ -62,7 +62,7 @@ cycles:
               - icon [date: 2026-05-01 00:00:00]
             name: 'cleanup'
             coordinates: {}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: []
             plugin: 'shell'
             command: 'python cleanup.py'

--- a/tests/cases/small-shell/config/config.yml
+++ b/tests/cases/small-shell/config/config.yml
@@ -34,18 +34,19 @@ cycles:
 tasks:
   - icon:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/icon.py
       command: "python icon.py --restart {PORT::restart} --init {PORT::init}"
       env_source_files: $TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh
   - cleanup:
       plugin: shell
-      computer: localhost
+      computer: remote
       src: scripts/cleanup.py
       command: "python cleanup.py"
 data:
   available:
      - icon_namelist:
+         # Different computer between task and available data
          computer: localhost
          src: /TESTS_ROOTDIR/tests/cases/small-shell/config/data/input
      - initial_conditions:

--- a/tests/cases/small-shell/config/config.yml
+++ b/tests/cases/small-shell/config/config.yml
@@ -37,7 +37,7 @@ tasks:
       computer: remote
       src: scripts/icon.py
       command: "python icon.py --restart {PORT::restart} --init {PORT::init}"
-      env_source_files: $TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh
+      env_source_files: /TESTS_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh
   - cleanup:
       plugin: shell
       computer: remote

--- a/tests/cases/small-shell/data/config.txt
+++ b/tests/cases/small-shell/data/config.txt
@@ -10,7 +10,7 @@ cycles:
               - icon_restart [date: 2026-01-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 1, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init}'
@@ -26,7 +26,7 @@ cycles:
               - icon_restart [date: 2026-03-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 3, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init}'
@@ -42,7 +42,7 @@ cycles:
               - icon_restart [date: 2026-05-01 00:00:00]
             name: 'icon'
             coordinates: {'date': datetime.datetime(2026, 5, 1, 0, 0)}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init}'
@@ -54,7 +54,7 @@ cycles:
               - icon [date: 2026-05-01 00:00:00]
             name: 'cleanup'
             coordinates: {}
-            computer: 'localhost'
+            computer: 'remote'
             cycle point: []
             plugin: 'shell'
             command: 'python cleanup.py'

--- a/tests/cases/small-shell/data/config.txt
+++ b/tests/cases/small-shell/data/config.txt
@@ -14,7 +14,7 @@ cycles:
             cycle point: [2026-01-01 00:00:00 -- 2026-03-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init}'
-            env source files: ['$TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
+            env source files: ['/TESTS_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-03-01 00:00:00]:
       tasks:
         - icon [date: 2026-03-01 00:00:00]:
@@ -30,7 +30,7 @@ cycles:
             cycle point: [2026-03-01 00:00:00 -- 2026-05-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init}'
-            env source files: ['$TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
+            env source files: ['/TESTS_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
   - bimonthly_tasks [date: 2026-05-01 00:00:00]:
       tasks:
         - icon [date: 2026-05-01 00:00:00]:
@@ -46,7 +46,7 @@ cycles:
             cycle point: [2026-05-01 00:00:00 -- 2026-06-01 00:00:00]
             plugin: 'shell'
             command: 'python icon.py --restart {PORT::restart} --init {PORT::init}'
-            env source files: ['$TEST_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
+            env source files: ['/TESTS_ROOTDIR/tests/cases/small-shell/config/data/dummy_source_file.sh']
   - lastly:
       tasks:
         - cleanup:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,7 @@ def config_paths(config_case, icon_grid_path, tmp_path, test_rootdir) -> dict[st
 
 def pytest_addoption(parser):
     parser.addoption("--reserialize", action="store_true", default=False)
+    parser.addoption("--remote", action="store", default=None, default=False, help="Specify an aiida computer label for a remote machine that has been configured before tests and should be used.")
 
 
 def serialize_worklfow(config_paths: dict[str, pathlib.Path], workflow: workflow.Workflow) -> None:
@@ -194,6 +195,8 @@ def pytest_configure(config):
             serialize_worklfow(config_paths=config_paths, workflow=wf)
             serialize_nml(config_paths=config_paths, workflow=wf)
 
+def aiida_remote_computer(request):
+    request.config.getoption("remote")
 
 @pytest.fixture(scope="session")
 def test_rootdir(pytestconfig):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,13 @@ import logging
 import pathlib
 import shutil
 import subprocess
+import typing as t
+import os
 
 import pytest
 import requests
 from aiida.common import NotExistent
-from aiida.orm import load_computer
+from aiida.orm import load_computer, Computer
 
 from sirocco import pretty_print
 from sirocco.core import _tasks as core_tasks
@@ -192,27 +194,91 @@ def pytest_configure(config):
             serialize_nml(config_paths=config_paths, workflow=wf)
 
 
-@pytest.fixture
-def aiida_localhost_ssh(aiida_computer_ssh):
-    try:
-        computer = load_computer("remote")
-    except NotExistent:
-        computer = aiida_computer_ssh(label="remote")
-    return computer
+# Copied over from aiida-core and made session-scoped, using `tmp_path_factory`
+@pytest.fixture(scope="session")
+def aiida_computer_session(tmp_path_factory) -> t.Callable[[], "Computer"]:
+    """Return a factory to create a new or load an existing :class:`aiida.orm.computers.Computer` instance.
+
+    The database is queried for an existing computer with the same ``label``, ``hostname``, ``scheduler_type`` and
+    ``transport_type``. If it exists, it means it was probably created by this fixture in a previous call and it is
+    simply returned. Otherwise a new instance is created. Note that the computer is not explicitly configured, unless
+    ``configure_kwargs`` are specified. By default the ``localhost`` hostname is used with the ``core.direct`` and
+    ``core.local`` scheduler and transport plugins.
+
+    The factory has the following signature:
+
+    :param label: The computer label. If not specified, a random UUID4 is used.
+    :param hostname: The hostname of the computer. Defaults to ``localhost``.
+    :param scheduler_type: The scheduler plugin to use. Defaults to ``core.direct``.
+    :param transport_type: The transport plugin to use. Defaults to ``core.local``.
+    :param minimum_job_poll_interval: The default minimum job poll interval to set. Defaults to 0.
+    :param default_mpiprocs_per_machine: The default number of MPI procs to set. Defaults to 1.
+    :param configuration_kwargs: Optional keyword arguments that, if defined, are used to configure the computer
+        by calling :meth:`aiida.orm.computers.Computer.configure`.
+    :return: A stored computer instance.
+    """
+
+    def factory(
+        label: str | None = None,
+        hostname="localhost",
+        scheduler_type="core.direct",
+        transport_type="core.local",
+        minimum_job_poll_interval: int = 0,
+        default_mpiprocs_per_machine: int = 1,
+        configuration_kwargs: dict[t.Any, t.Any] | None = None,
+    ) -> "Computer":
+        import uuid
+
+        from aiida.common.exceptions import NotExistent
+        from aiida.orm import Computer
+
+        label = label or f"test-computer-{uuid.uuid4().hex}"
+
+        try:
+            computer = Computer.collection.get(
+                label=label, hostname=hostname, scheduler_type=scheduler_type, transport_type=transport_type
+            )
+        except NotExistent:
+            # Create a temporary directory for this computer instance
+            tmp_dir = tmp_path_factory.mktemp("aiida_computer")
+
+            computer = Computer(
+                label=label,
+                hostname=hostname,
+                workdir=str(tmp_dir),
+                transport_type=transport_type,
+                scheduler_type=scheduler_type,
+            )
+            computer.store()
+            computer.set_minimum_job_poll_interval(minimum_job_poll_interval)
+            computer.set_default_mpiprocs_per_machine(default_mpiprocs_per_machine)
+
+        if configuration_kwargs:
+            computer.configure(**configuration_kwargs)
+
+        return computer
+
+    return factory
 
 
-@pytest.fixture
-def aiida_remote_computer(request, aiida_localhost_ssh):
+@pytest.fixture(scope="session")
+def aiida_remote_computer(request, aiida_computer_session):
     comp_spec = request.config.getoption("remote")
 
-    # PRCOMMENT: This is just the normal localhost fixture. So we remove that option and just use the default
-    # `aiida_localhost` fixture, in addition to the `aiida_remote_computer` one that depends on the pytest-marker
-    # if comp_spec == 'localhost-local':
-    #     # Create localhost_local
-    #     aiida_localhost_local
     if comp_spec == "localhost-ssh":
-        # Create localhost_ssh
-        _ = aiida_localhost_ssh
+        try:
+            computer = load_computer("remote")
+        except NotExistent:
+            computer = aiida_computer_session(label="remote", hostname="localhost", transport_type="core.ssh")
+
+            computer.configure(
+                key_filename=f"{os.environ['HOME']}/.ssh/id_rsa",
+                key_policy="AutoAddPolicy",
+                safe_interval=1.0,
+            )
+
+        return computer
+
     elif comp_spec == "cscs-ci":
         # PRCOMMENT: Add this infrastructure in another PR
         msg = "Infrastructure for FirecREST net setup yet."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 import logging
+import os
 import pathlib
 import shutil
 import subprocess
 import typing as t
-import os
 
 import pytest
 import requests
 from aiida.common import NotExistent
-from aiida.orm import load_computer, Computer
+from aiida.orm import Computer, load_computer
 
 from sirocco import pretty_print
 from sirocco.core import _tasks as core_tasks
@@ -279,7 +279,7 @@ def aiida_remote_computer(request, aiida_computer_session):
 
         return computer
 
-    elif comp_spec == "cscs-ci":
+    elif comp_spec == "cscs-ci":  # noqa: RET505 | superfluous-else-return
         # PRCOMMENT: Add this infrastructure in another PR
         msg = "Infrastructure for FirecREST net setup yet."
         raise NotImplementedError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,13 +274,12 @@ def aiida_remote_computer(request, aiida_computer_session):
             computer.configure(
                 key_filename=f"{os.environ['HOME']}/.ssh/id_rsa",
                 key_policy="AutoAddPolicy",
-                safe_interval=1.0,
+                safe_interval=0.1,
             )
 
         return computer
 
     elif comp_spec == "cscs-ci":  # noqa: RET505 | superfluous-else-return
-        # PRCOMMENT: Add this infrastructure in another PR
         msg = "Infrastructure for FirecREST net setup yet."
         raise NotImplementedError(msg)
     else:

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -32,7 +32,7 @@ def test_icon():
 
 # configs that are tested for running workgraph
 @pytest.mark.slow
-@pytest.mark.usefixtures("config_case", "aiida_localhost")
+@pytest.mark.usefixtures("config_case", "aiida_localhost", "aiida_remote_computer")
 @pytest.mark.parametrize(
     "config_case",
     [
@@ -55,7 +55,7 @@ def test_run_workgraph(config_paths):
 
 
 @pytest.mark.requires_icon
-@pytest.mark.usefixtures("config_case", "aiida_localhost", "aiida_localhost_ssh")
+@pytest.mark.usefixtures("config_case", "aiida_localhost", "aiida_remote_computer")
 @pytest.mark.parametrize(
     "config_case",
     [

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -46,14 +46,9 @@ def test_run_workgraph(config_paths):
     Automatically uses the aiida_profile fixture to create a new profile. Note to debug the test with your profile
     please run this in a separate file as the profile is deleted after test finishes.
     """
-    # from aiida import orm
-    # comps = orm.QueryBuilder().append(orm.Computer).all(flat=True)
-    # print([c.get_transport_class() for c in comps])
-    # import ipdb; ipdb.set_trace()
     core_workflow = Workflow.from_config_file(str(config_paths["yml"]))
     aiida_workflow = AiidaWorkGraph(core_workflow)
     output_node = aiida_workflow.run()
-
     assert (
         output_node.is_finished_ok
     ), f"Not successful run. Got exit code {output_node.exit_code} with message {output_node.exit_message}."

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -46,9 +46,14 @@ def test_run_workgraph(config_paths):
     Automatically uses the aiida_profile fixture to create a new profile. Note to debug the test with your profile
     please run this in a separate file as the profile is deleted after test finishes.
     """
+    from aiida import orm
+    comps = orm.QueryBuilder().append(orm.Computer).all(flat=True)
+    print([c.get_transport_class() for c in comps])
+    import ipdb; ipdb.set_trace()
     core_workflow = Workflow.from_config_file(str(config_paths["yml"]))
     aiida_workflow = AiidaWorkGraph(core_workflow)
     output_node = aiida_workflow.run()
+
     assert (
         output_node.is_finished_ok
     ), f"Not successful run. Got exit code {output_node.exit_code} with message {output_node.exit_message}."

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -46,10 +46,10 @@ def test_run_workgraph(config_paths):
     Automatically uses the aiida_profile fixture to create a new profile. Note to debug the test with your profile
     please run this in a separate file as the profile is deleted after test finishes.
     """
-    from aiida import orm
-    comps = orm.QueryBuilder().append(orm.Computer).all(flat=True)
-    print([c.get_transport_class() for c in comps])
-    import ipdb; ipdb.set_trace()
+    # from aiida import orm
+    # comps = orm.QueryBuilder().append(orm.Computer).all(flat=True)
+    # print([c.get_transport_class() for c in comps])
+    # import ipdb; ipdb.set_trace()
     core_workflow = Workflow.from_config_file(str(config_paths["yml"]))
     aiida_workflow = AiidaWorkGraph(core_workflow)
     output_node = aiida_workflow.run()

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -6,7 +6,7 @@ from sirocco.workgraph import AiidaWorkGraph
 
 
 # Hardcoded, explicit integration test based on the `parameters` case for now
-@pytest.mark.usefixtures("aiida_localhost", "config_case")
+@pytest.mark.usefixtures("config_case", "aiida_localhost", "aiida_remote_computer")
 @pytest.mark.parametrize(
     "config_case",
     [
@@ -116,7 +116,7 @@ def test_shell_filenames_nodes_arguments(config_paths):
     assert nodes_list == expected_nodes_list
 
 
-@pytest.mark.usefixtures("aiida_localhost", "config_case")
+@pytest.mark.usefixtures("config_case", "aiida_localhost", "aiida_remote_computer")
 @pytest.mark.parametrize(
     "config_case",
     [


### PR DESCRIPTION
This allows us the adapt the computer setup for different CI setups. Work on this after merging #186 

TODO:
- [x] rename localhost_ssh -> remote (and use remote computer everywhere for the tasks)
- [x] All remote files need be transported to remote as a preparation of the tests
