### PR TITLE
Add error logs on WorkGraph failures in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ sirocco = "sirocco.cli:app"
 
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)
-log_level = "WARNING"
+log_level = "ERROR"
 log_cli = true
-log_cli_level = "WARNING"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s"
+log_cli_level = "ERROR"
+log_cli_format = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 addopts = "--pdbcls=IPython.terminal.debugger:TerminalPdb"
 norecursedirs = "tests/cases"
 markers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from sirocco.parsing import yaml_data_models as models
 
 pytest_plugins = ["aiida.tools.pytest_fixtures"]
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class DownloadError(RuntimeError):
@@ -43,10 +43,10 @@ def icon_grid_path(pytestconfig):
 
     # Check if the file is already cached
     if icon_grid_path.exists():
-        logger.info("Found icon grid in cache, reusing it.")
+        LOGGER.info("Found icon grid in cache, reusing it.")
     else:
         # File is not cached, download and save it
-        logger.info("Downloading and caching icon grid.")
+        LOGGER.info("Downloading and caching icon grid.")
         download_file(url, icon_grid_path)
 
     return icon_grid_path
@@ -185,7 +185,7 @@ def serialize_nml(config_paths: dict[str, pathlib.Path], workflow: workflow.Work
 
 def pytest_configure(config):
     if config.getoption("reserialize"):
-        logger.info("Regenerating serialized references")
+        LOGGER.info("Regenerating serialized references")
         for config_case in ALL_CONFIG_CASES:
             config_paths = generate_config_paths(config_case)
             for key, value in config_paths.items():

--- a/tests/test_wc_workflow.py
+++ b/tests/test_wc_workflow.py
@@ -8,7 +8,7 @@ from sirocco.core._tasks.icon_task import IconTask
 from sirocco.vizgraph import VizGraph
 from sirocco.workgraph import AiidaWorkGraph
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def test_parse_config_file(config_paths, pprinter):
@@ -56,11 +56,11 @@ def test_run_workgraph(config_paths):
         from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report
 
         # overall report but often not enough to really find the bug, one has to go to calcjob
-        logger.warning("Workchain report:\n%s", get_workchain_report(output_node, levelname="REPORT"))
+        LOGGER.error("Workchain report:\n%s", get_workchain_report(output_node, levelname="REPORT"))
         # the calcjobs are typically stored in 'called_descendants'
         for node in output_node.called_descendants:
-            logger.warning("%s workdir: %s", node.process_label, node.get_remote_workdir())
-            logger.warning("%s report:\n%s", node.process_label, get_calcjob_report(node))
+            LOGGER.error("%s workdir: %s", node.process_label, node.get_remote_workdir())
+            LOGGER.error("%s report:\n%s", node.process_label, get_calcjob_report(node))
     assert (
         output_node.is_finished_ok
     ), f"Not successful run. Got exit code {output_node.exit_code} with message {output_node.exit_message}."
@@ -97,11 +97,11 @@ def test_run_workgraph_with_icon(icon_filepath_executable, config_paths, tmp_pat
         from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report
 
         # overall report but often not enough to really find the bug, one has to go to calcjob
-        logger.warning("Workchain report:\n%s", get_workchain_report(output_node, levelname="REPORT"))
+        LOGGER.error("Workchain report:\n%s", get_workchain_report(output_node, levelname="REPORT"))
         # the calcjobs are typically stored in 'called_descendants'
         for node in output_node.called_descendants:
-            logger.warning("%s workdir: %s", node.process_label, node.get_remote_workdir())
-            logger.warning("%s report:\n%s", node.process_label, get_calcjob_report(node))
+            LOGGER.error("%s workdir: %s", node.process_label, node.get_remote_workdir())
+            LOGGER.error("%s report:\n%s", node.process_label, get_calcjob_report(node))
 
     assert (
         output_node.is_finished_ok


### PR DESCRIPTION
Use `WARNING` log level for now. Tried setting it to `INFO`, but this leads to a bunch of log messages from AiiDA and its dependencies. Tried a few ways to capture those, but they didn't work. Would keep it at warning for now, and not invest more time.