### PR TITLE
Remove `filterwarnings` conflicting with aiida EBM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,6 @@ Changelog = "https://github.com/C2SM/Sirocco/blob/main/CHANGELOG.md"
 [project.scripts]
 sirocco = "sirocco.cli:app"
 
-filterwarnings = [
-  "ignore::UserWarning",
-  'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning',  # from aio_pika via duration
-  "ignore:There is no current event loop:DeprecationWarning",  # from plumpy via aiida testing tools
-  "ignore:Object of type <DbNode> not in session:sqlalchemy.exc.SAWarning",  # sqlalchemy via aiida testing tools
-]
-
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)
 log_level = "ERROR"
@@ -72,6 +65,13 @@ norecursedirs = "tests/cases"
 markers = [
   "slow: slow integration tests which are not recommended to run locally for normal development",
   "requires_icon: marks test to require icon installation"
+]
+
+filterwarnings = [
+  "ignore::UserWarning",
+  'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning',  # from aio_pika via duration
+  "ignore:There is no current event loop:DeprecationWarning",  # from plumpy via aiida testing tools
+  "ignore:Object of type <DbNode> not in session:sqlalchemy.exc.SAWarning",  # sqlalchemy via aiida testing tools
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ Changelog = "https://github.com/C2SM/Sirocco/blob/main/CHANGELOG.md"
 [project.scripts]
 sirocco = "sirocco.cli:app"
 
+filterwarnings = [
+  "ignore::UserWarning",
+  'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning',  # from aio_pika via duration
+  "ignore:There is no current event loop:DeprecationWarning",  # from plumpy via aiida testing tools
+  "ignore:Object of type <DbNode> not in session:sqlalchemy.exc.SAWarning",  # sqlalchemy via aiida testing tools
+]
+
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)
 log_level = "ERROR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "isoduration",
   "pydantic",
   "ruamel.yaml",
-  "aiida-core>=2.5,<2.7.0",
+  "aiida-core>=2.5",
   "aiida-icon>=0.4.0",
   "aiida-workgraph==0.5.2",
   "termcolor",
@@ -65,13 +65,6 @@ norecursedirs = "tests/cases"
 markers = [
   "slow: slow integration tests which are not recommended to run locally for normal development",
   "requires_icon: marks test to require icon installation"
-]
-filterwarnings = [
-  "error",
-  "ignore::UserWarning",
-  'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning',  # from aio_pika via duration
-  "ignore:There is no current event loop:DeprecationWarning",  # from plumpy via aiida testing tools
-  "ignore:Object of type <DbNode> not in session:sqlalchemy.exc.SAWarning",  # sqlalchemy via aiida testing tools
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
The pytest mechanism erroring out for thrown warnings can interrupt aiida in a transport task. In this case the EBM (exponential backoff mechanism) of aiida catches the pytest error and blocks the test suite in erroring out. 
In the new aiida release transport throws a deprecation waring. This results in intransparent error state as pytest's error message is never printed out.

To solve this issues one could add a ignore for `aiida.common.warnings.AiidaDeprecationWarning` into `filterwarnings` but I am afraid that in the future another warning is thrown in the transport that we do not filter resulting again in this intransparent error. This might be an upstream problem of aiida-core since it does not properly prints the error but I am also not sure how pytest interrupts a test during a warning (since interrupting signal stops EBM). This is why I for now removed the mechanism to error out during warnings removing `filterwarnings`. I think I would be also okay to include it but ignore all aiida warnings so this cannot happen again.