### PR TITLE
`localhost` with `core.local` as default for local tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--remote",
         action="store",
-        default="localhost-ssh",
+        default="localhost",
         help="Specify an aiida computer label for a remote machine that has been configured before tests and should be used.",
     )
 
@@ -266,7 +266,14 @@ def aiida_computer_session(tmp_path_factory) -> t.Callable[[], "Computer"]:
 def aiida_remote_computer(request, aiida_computer_session, test_rootdir):
     comp_spec = request.config.getoption("remote")
 
-    if comp_spec == "localhost-ssh":
+    if comp_spec == "localhost":
+        try:
+            computer = load_computer("remote")
+        except NotExistent:
+            computer = aiida_computer_session(label="remote", hostname="localhost", transport_type="core.local")
+            computer.configure(safe_interval=0)
+
+    elif comp_spec == "localhost-ssh":
         try:
             computer = load_computer("remote")
         except NotExistent:


### PR DESCRIPTION
Using `localhost-ssh` by default requires OpenSSH server to be correctly set up on the local machine. In addition, one needs a valid private key, which is something that can cause problems with paramiko, as the default key, or using `ssh-keygen -t rsa` doesn't produce a valid key (see [this issue](https://github.com/paramiko/paramiko/issues/2048)). 

Instead, we change the default computer to `localhost`~-ssh~ but still use `localhost-ssh` or `cscs-ci` computers as specified in the CI YAML config files.

Note: `localhost-ssh` _does_ work with the following setup (assuming OpenSSH server is installed and sshd running):
```shell
❯ ssh-keygen -t ed25519 -f ~/.ssh/id_rsa
Generating public/private ed25519 key pair.
❯ eval "$(ssh-agent -s)"
Agent pid 90010
❯ ssh-add ~/.ssh/id_rsa
Identity added: /home/geiger_j/.ssh/id_rsa (geiger_j@mpc3152)
```