### PR TITLE
Pin `click<8.3.0` in CI in "Install hatch" steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
     - name: Install hatch
       run: |
         pip install --upgrade pip
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
     - name: Install Graphviz
       run: sudo apt-get install graphviz graphviz-dev
@@ -66,6 +67,7 @@ jobs:
     - name: Install hatch
       run: |
         pip install --upgrade pip
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
     - name: Install Graphviz
       run: sudo apt-get install graphviz graphviz-dev
@@ -88,6 +90,7 @@ jobs:
     - name: Install hatch
       run: |
         pip install --upgrade pip
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
     - name: Install Graphviz
       run: sudo apt-get install graphviz graphviz-dev
@@ -110,7 +113,7 @@ jobs:
     - name: Install hatch
       run: |
         pip install --upgrade pip
-        pip install "click<8.3.0"
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
     - name: Install Graphviz
       run: sudo apt-get install graphviz graphviz-dev

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Install hatch
       run: |
         pip install --upgrade pip
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
 
     - name: Install Graphviz

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Install hatch
       run: |
         pip install --upgrade pip
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
     - name: Publish package
       env:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -68,6 +68,7 @@ jobs:
       run: |
         spack env activate .
         pip install --upgrade pip
+        pip install "click<8.3.0"  # NOTE: click 8.2 -> 8.3 is backwards incompatible
         pip install hatch
         hatch run verdi presto
 


### PR DESCRIPTION
`hatch` itself has `click` as a dependency as `"click>=8.0.6"`:
https://github.com/pypa/hatch/blob/4ebce0e1fe8bf0fcdef587a704c207a063d72575/pyproject.toml#L41-L42
`click 8.3.0` was released on 2025-09-18, with backwards incompatible changes. Hence, we explicitly install it via `<8.3.0` before `pip install hatch` in all "Install hatch" steps. I previously tried pinning click in our `types` `hatch` env, but that didn't fix it, as in CI `click v8.3.0` was again installed as dependency of `hatch`. Thanks to @agoscinski for figuring out `click` was the cause for CI failing in #223.